### PR TITLE
Bump to 0.7.26 — drop implausible energy-counter spikes before forecasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.26 - 2026-06-05
+
+- **Fix:** Drop implausible energy-counter spikes from Home Assistant statistics before they reach the load/PV predictor. A meter reset on 2026-05-30 (coinciding with a Venus MQTT update) recorded one period as ~4296 kWh; under `mean` aggregation this averaged into a ~538 kWh forecast load for a single slot, which exceeded the grid import cap and made the LP **infeasible** — producing an empty schedule. `postprocess()` now discards any per-period reading whose magnitude exceeds `MAX_PLAUSIBLE_SLOT_ENERGY_WH` (25 kWh, overridable via the new `{ maxSlotEnergyWh }` option) and logs a `[ha-postprocess]` warning naming the sensor, timestamp, and value. The dropped sample becomes a gap, which the historical predictor already skips, so it no longer poisons the mean/median or the auto-tuner's validation metrics.
+
 ## 0.7.25 - 2026-06-05
 
 - **Fix:** Victron MQTT portal-id auto-detection now derives the id from the `N/<portal-id>/system/0/Serial` topic instead of trusting the JSON payload. On the target broker, live MQTT returned SoC on `N/c0619ab6bd28/battery/512/Soc` and `N/c0619ab6bd28/system/0/Dc/Battery/Soc`, while the failed calculate path had been waiting on `N/2/...`; using the topic id prevents calculate-time SoC refreshes from addressing the wrong MQTT namespace.

--- a/lib/ha-postprocess.ts
+++ b/lib/ha-postprocess.ts
@@ -31,6 +31,18 @@ export interface HaReading {
 }
 
 /**
+ * Default ceiling for a single statistics period's energy (Wh).
+ *
+ * Any per-period value above this is treated as a sensor artifact (an
+ * energy-counter reset or jump, e.g. after a firmware/MQTT update) rather than
+ * real consumption, and dropped. The cap is well above any plausible slot on a
+ * domestic system but far below a counter-reset spike (which can be megawatt-
+ * hours). A single such spike would otherwise poison the historical mean and
+ * can make the LP infeasible by demanding more load than the grid can supply.
+ */
+export const MAX_PLAUSIBLE_SLOT_ENERGY_WH = 25_000;
+
+/**
  * Get all unique sensor names present in processed data.
  */
 export function getSensorNames(data: StatRecord[]): string[] {
@@ -77,6 +89,7 @@ export function postprocess(
   rawData: Record<string, HaReading[]>,
   sensors: HaSensor[],
   derived: HaDerivedSensor[],
+  { maxSlotEnergyWh = MAX_PLAUSIBLE_SLOT_ENERGY_WH }: { maxSlotEnergyWh?: number } = {},
 ): StatRecord[] {
   const nameOf = Object.fromEntries(sensors.map(s => [s.id, s.name]));
   const unitOf = Object.fromEntries(sensors.map(s => [s.id, s.unit]));
@@ -84,11 +97,19 @@ export function postprocess(
   const flat = Object.entries(rawData).flatMap(([id, readings]) => {
     const name = nameOf[id] ?? id;
     const multiplier = unitOf[id] === 'kWh' ? 1000 : 1;
-    return readings.map(d => ({
-      time: d.start,
-      sensor: name,
-      value: (d.change ?? 0) * multiplier,
-    }));
+    return readings.flatMap(d => {
+      const value = (d.change ?? 0) * multiplier;
+      // Drop implausible spikes (counter resets/jumps) before they reach the
+      // merge, derived series, predictor, and validation metrics.
+      if (Math.abs(value) > maxSlotEnergyWh) {
+        console.warn(
+          `[ha-postprocess] dropping implausible ${name} sample at ${new Date(d.start).toISOString()}: ` +
+          `${(value / 1000).toFixed(1)} kWh exceeds ${(maxSlotEnergyWh / 1000).toFixed(0)} kWh cap`,
+        );
+        return [];
+      }
+      return [{ time: d.start, sensor: name, value }];
+    });
   });
 
   // Merge sensors with the same name (e.g. DSMR tariff 1+2)

--- a/optivolt/config.yaml
+++ b/optivolt/config.yaml
@@ -1,6 +1,6 @@
 name: Optivolt
 slug: optivolt
-version: "0.7.25"
+version: "0.7.26"
 description: Plan and control Victron ESS with forecasts & dynamic tariffs!
 url: https://github.com/vervoto1/optivolt
 image: "ghcr.io/vervoto1/{arch}-addon-optivolt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optivolt",
-  "version": "0.7.25",
+  "version": "0.7.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optivolt",
-      "version": "0.7.25",
+      "version": "0.7.26",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optivolt",
-  "version": "0.7.25",
+  "version": "0.7.26",
   "description": "Optivolt is a linear and mixed-integer optimizer for home energy systems.",
   "homepage": "https://github.com/bmesuere/optivolt#readme",
   "bugs": {

--- a/tests/lib/ha-postprocess.test.js
+++ b/tests/lib/ha-postprocess.test.js
@@ -62,6 +62,48 @@ describe('postprocess', () => {
     const data = postprocess({}, sensors, derived);
     expect(data).toEqual([]);
   });
+
+  it('drops implausible spikes (counter resets) above the cap', () => {
+    const spikeRaw = {
+      'sensor.solar': [
+        { start: t1, change: 500 },
+        { start: t2, change: 4_296_000 }, // 4296 kWh counter-reset artifact
+      ],
+    };
+    const data = postprocess(spikeRaw, sensors, []);
+    const solar = data.filter(d => d.sensor === 'Solar');
+    expect(solar).toHaveLength(1);
+    expect(solar[0].value).toBe(500);
+  });
+
+  it('drops negative spikes below the cap', () => {
+    const spikeRaw = {
+      'sensor.solar': [{ start: t1, change: -4_296_000 }],
+    };
+    const data = postprocess(spikeRaw, sensors, []);
+    expect(data.filter(d => d.sensor === 'Solar')).toHaveLength(0);
+  });
+
+  it('keeps values at the cap and drops values above it', () => {
+    const raw = {
+      'sensor.solar': [
+        { start: t1, change: 25_000 }, // exactly at cap → kept
+        { start: t2, change: 25_001 }, // just over → dropped
+      ],
+    };
+    const data = postprocess(raw, sensors, []);
+    const solar = data.filter(d => d.sensor === 'Solar');
+    expect(solar).toHaveLength(1);
+    expect(solar[0].value).toBe(25_000);
+  });
+
+  it('honours a custom maxSlotEnergyWh override', () => {
+    const raw = {
+      'sensor.solar': [{ start: t1, change: 5_000 }],
+    };
+    const data = postprocess(raw, sensors, [], { maxSlotEnergyWh: 1_000 });
+    expect(data.filter(d => d.sensor === 'Solar')).toHaveLength(0);
+  });
 });
 
 describe('aggregateTo15Min', () => {


### PR DESCRIPTION
## Problem

The DESS schedule went empty because the LP was **infeasible**.

Root cause chain:
1. On **2026-05-30**, when Venus MQTT was updated, the HA load energy counter reset/jumped, so HA recorded one statistics period's `change` as **~4296 kWh**.
2. OptiVolt re-fetches that history live from HA every run. Under **`mean`** aggregation the historical predictor averaged the spike with ~7 normal days → `4296/8 ≈ 537` ≈ the observed **538.4 kWh** forecast load for the 13:00 slot.
3. That impossible load made the LP load-balance constraint unsatisfiable (≈2 MW demand vs. an 18 kW grid cap) → **Plan status: Infeasible** → no plan → **empty schedule**.

Switching to `median` masked it (median ignores one outlier) but left the bad sample poisoning the validation metrics / auto-tuner.

## Fix

A spike guard in `lib/ha-postprocess.ts`, applied at the raw-reading level — before merging, derived sensors, prediction, and validation consume it:

- New exported constant `MAX_PLAUSIBLE_SLOT_ENERGY_WH = 25_000` (Wh).
- Any per-period reading with `|value| > cap` is **dropped** (becomes a gap, which `predict()` already skips) and logged with a `[ha-postprocess]` warning naming the sensor, timestamp, and kWh value.
- Catches negatives too (counter rollbacks); cap overridable via a new optional 4th arg `{ maxSlotEnergyWh }` — backward-compatible, all existing 3-arg callers unchanged.

Protects `mean` and `median` equally, so a counter glitch can no longer skew forecasts or break the plan.

## Tests

5 new cases (drop positive/negative spikes, boundary at exactly 25 kWh kept vs. 25.001 dropped, custom override). 20/20 pass; typecheck + lint clean.

## Note (not in this PR)

The 4.3 MWh row still lives in HA's statistics — it'll now be logged-and-dropped each run. To remove it at source: **HA → Developer Tools → Statistics → Fix/Adjust** on the load sensor, or delete that period from the `statistics`/`statistics_short_term` tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)