### PR TITLE
plans: ESS dashboard tab + EV native charge planning & actuation

### DIFF
--- a/plans/ess-dashboard-tab-plan.md
+++ b/plans/ess-dashboard-tab-plan.md
@@ -17,6 +17,26 @@ The system has **two batteries** plus a Victron system view, so the tab must
 support **multiple batteries** generically (not hardcoded to two), driven by
 configuration with sensible defaults seeded for the current hardware.
 
+### Build-vs-link tradeoff (decided: build native)
+
+HA already renders this view in the `ess_system` Lovelace dashboard. Rebuilding
+it natively in OptiVolt is a deliberate choice, with a real cost worth stating so
+it's a decision and not an accident:
+
+- **Why native (the call):** unified OptiVolt look/feel, light/dark theme, and a
+  single pane that sits next to the optimizer — no context switch to HA, no
+  embedded iframes/cards that don't match the rest of the UI.
+- **What it costs:** this duplicates a working dashboard, couples it to OptiVolt's
+  release cycle, and exposes it to **entity-id drift** (the seeded defaults hold
+  hardcoded ids — Victron device id `c0619ab6bd28`, JK BMS prefixes). A BMS
+  firmware update or entity rename silently breaks the seeded mapping.
+- **Mitigation (required):** on load, **validate** that each configured entity id
+  resolves; render missing entities as an explicit "sensor not found" placeholder
+  per tile/series rather than a blank chart, and never let one missing id blank
+  the tab (this aligns with the per-entity failure tolerance in the backend).
+  If link/iframe is ever preferred, that remains a fallback — but the native
+  build is the chosen path.
+
 ### Source dashboard being reproduced
 
 The Home Assistant dashboard (`.storage/lovelace.ess_system` in the
@@ -94,9 +114,25 @@ Read these before starting; the feature plugs into existing plumbing.
   helpers (`toRGBA`, `dim`, `getBuyPriceColor`) live in `app/src/charts/colors.js`.
 - **Tabs.** Tab buttons live in the `<nav role="tablist">` in `app/index.html`;
   panels are `<div role="tabpanel" id="panel-...">`. `setupTabSwitcher()` in
-  `app/main.js` builds a `tabs` array and crossfades panels. The Predictions tab
-  is initialized lazily in `boot()` via `initPredictionsTab()` — mirror that for
-  ESS so the tab does no HA I/O until first shown.
+  `app/main.js` builds a `tabs` array and crossfades panels.
+  - **Correction (do not "mirror Predictions" for laziness).** Predictions is
+    NOT lazy — `app/main.js:117` calls `await initPredictionsTab()` *eagerly* in
+    `boot()`. There is **no** existing per-tab lazy-init hook. To keep startup
+    free of ESS HA traffic (an acceptance criterion), you must **add** a per-tab
+    "activated once" hook in `activateTab()` (or a one-shot guard on the `tab-ess`
+    click handler) and call `initEssTab()` from there — do not init ESS in
+    `boot()`.
+  - **Tab vs panel ordering.** Visual order is set by the **nav button** DOM
+    order (`tab-optimizer`, `tab-ev`, `tab-predictions`, `tab-settings` today),
+    so insert the `tab-ess` button between `tab-ev` and `tab-predictions`. The
+    **panel** elements are show/hidden by id and their DOM position is irrelevant
+    (today `panel-ev` is actually the *last* panel in `index.html`). Place
+    `panel-ess` anywhere sensible; do not try to slot it "between the EV and
+    Predictions panels" — that ordering doesn't exist in the panel DOM. Also note
+    the `tabs` array in `setupTabSwitcher()` is in a different order than the DOM
+    (Optimizer, Predictions, EV, Settings); it pairs each tab with its own panel,
+    so array position doesn't affect routing — just add the ESS `{tab, panel}`
+    entry.
 
 ### UI style tokens to reuse (from `app/index.html`)
 
@@ -191,10 +227,20 @@ Two functions, both pure orchestration over `ha-client.ts`:
      configured (mirror `api/routes/ha.ts`).
   2. Expand each battery's cell-voltage entity list (prefix+count or explicit).
   3. Collect **all** scalar + cell + temperature entity ids across batteries and
-     system into one set, fetch their live states **concurrently** with
-     `Promise.allSettled` over `fetchHaEntityState`. Tolerate per-entity
-     failures (return `null` value for that entity) so one missing sensor never
-     blanks the whole tab.
+     system into one set, then fetch their live states.
+
+     > **Use the bulk states endpoint, not N per-entity GETs.** A naive
+     > `Promise.allSettled` over `fetchHaEntityState` issues one HTTP GET *per
+     > entity* — ~16 cells + 5 temps + ~12 scalars per battery × 2 batteries ≈
+     > 60+ requests to the supervisor proxy on **every** refresh (default every
+     > 30 s while the tab is open). HA exposes `GET /api/states` (all entity
+     > states in **one** request — a Layer-1 built-in). Add a
+     > `fetchHaEntityStates()` to `ha-client.ts` (one bulk call via
+     > `resolveHaHttpConfig`), fetch once, and filter/index the result by the
+     > entity ids you need. Keep per-entity tolerance: an id absent from the bulk
+     > result yields a `null` value for that tile/series, so one missing sensor
+     > never blanks the tab (and a renamed/dropped entity surfaces as "not found",
+     > supporting the entity-drift mitigation in the Goal section).
   4. Shape into a structured response:
 
      ```ts
@@ -219,15 +265,43 @@ Two functions, both pure orchestration over `ha-client.ts`:
   4. Return the raw per-entity reading arrays keyed by entity id, plus the
      `hours`/`period` echoed back. (The client maps these into Chart.js series.)
 
+  > **CRITICAL — statistics vs raw history (trend charts can come up empty).**
+  > `fetchHaStats` calls `recorder/statistics_during_period`, which only returns
+  > data for entities that have **long-term statistics** (a `state_class` of
+  > `measurement`/`total` *and* the recorder configured to keep statistics for
+  > them). Per-cell JK BMS voltages and cell-temperature sensors frequently have
+  > **no `state_class`** or are excluded from the recorder, in which case
+  > `statistics_during_period` returns an **empty array — not an error** — and the
+  > trend charts silently render blank for exactly the data this tab is built
+  > around. (The source Lovelace dashboard mixes `statistics-graph` cards with
+  > `history-graph` cards; the latter read raw history, a different API.) Do this:
+  >
+  > 1. **Verify first.** Add a one-time/diagnostic check (a `GET /ess/history`
+  >    self-test or a startup log) that reports, per configured entity, whether
+  >    statistics exist. Surface "no statistics" entities in the response so the
+  >    UI can label them instead of drawing an empty chart.
+  > 2. **Add a raw-history fallback.** Add `fetchHaHistory()` to `ha-client.ts`
+  >    using `history/history_during_period` (REST `GET /api/history/period/...`,
+  >    or the WS `history/history_during_period` command) for entities that lack
+  >    statistics. `getEssHistory` chooses per entity: statistics where available
+  >    (cheap, pre-aggregated), raw history otherwise. Raw history is higher
+  >    volume — clamp the window and/or downsample client-side.
+  >
+  > This is the headline risk for the tab: without it, the cell-voltage trends —
+  > the main reason the dashboard exists — may ship blank.
+
 ### New route: `api/routes/ess.ts`
 
 - `GET /ess/state` → `getEssState(loadSettings())`.
 - `GET /ess/history?hours=24&period=5minute` → `getEssHistory(...)` with query
   parsing + clamping (`hours` 1..168, `period` whitelist).
-- Optional, **phase 2**: `POST /ess/max-charge-current` to write the Victron ESS
-  max charge current. This requires an HA service call (`number/set_value`),
-  which OptiVolt does not currently issue. Leave the field **read-only in
-  phase 1**; document the service-call approach in a code comment and defer.
+- Optional, **phase 8** (deferred): `POST /ess/max-charge-current` to write the
+  Victron ESS max charge current. This requires an HA service call
+  (`number/set_value`). **Cross-plan dependency:** that write path is exactly the
+  generic `callHaService()` the EV native-charging plan adds to `ha-client.ts`
+  (its phase 8). Build `callHaService` once in the EV work and have this reuse it —
+  do not duplicate. Sequence: EV phase 8 before ESS phase 8. Leave the field
+  **read-only** until then.
 
 Mount in `api/app.ts` next to the other routers: `app.use('/ess', essRouter)`.
 
@@ -348,17 +422,25 @@ Follow `AGENTS.md` PR/testing notes. Run `npm run typecheck`, `npm run lint`
 (it lints `.md`/`.css` too), and `npm run test:run`.
 
 - **Service tests** (`tests/api/ess-service.test.js`): mock `ha-client.ts`
-  (`fetchHaEntityState`, `fetchHaStats`) and assert: cell-prefix expansion;
-  concurrent fetch; per-entity failure tolerance (one rejected entity → `null`
-  value, others still populated); correct entity-id set passed to
-  `fetchHaStats`; `startTime` derived from `hours`.
+  (`fetchHaEntityStates` bulk reader, `fetchHaStats`, `fetchHaHistory`) and
+  assert: cell-prefix expansion; **one** bulk states call (not N per-entity
+  GETs); per-entity tolerance (an id absent from the bulk result → `null` value,
+  others still populated); correct entity-id set passed to `fetchHaStats`;
+  `startTime` derived from `hours`.
+  - **Statistics-empty → history fallback.** When `fetchHaStats` returns an empty
+    array for a cell entity (no `state_class`), `getEssHistory` falls back to
+    `fetchHaHistory` for that entity and the series is populated. Guards the
+    headline "blank trend charts" risk.
 - **Route tests** (`tests/api/ess-routes.test.js`, supertest): 200 shape for
   `/ess/state` and `/ess/history`; 422 when HA unconfigured; query clamping on
-  `hours`/`period`.
+  `hours`/`period`; `/ess/history` reports which entities lack statistics.
 - **Browser tests** (`tests/app/ess-tab.test.js`, jsdom): given a mocked state
   response, `initEssTab()` builds N battery cards; given a 422 it shows the
-  empty state without throwing; tab registers in the switcher and is positioned
-  between EV and Predictions in the nav DOM order.
+  empty state without throwing; a missing/renamed entity renders a "not found"
+  placeholder (not a blank chart); tab registers in the switcher; the `tab-ess`
+  **button** sits between `tab-ev` and `tab-predictions` in the nav DOM;
+  `initEssTab()` is **not** called during `boot()` (no ESS HA traffic until the
+  tab is first activated).
 
 No version bump is required unless `optivolt/` add-on files change (they do not
 for this feature) — see the versioning rules in `CLAUDE.md`. If a release is

--- a/plans/ess-dashboard-tab-plan.md
+++ b/plans/ess-dashboard-tab-plan.md
@@ -1,0 +1,384 @@
+# ESS System Dashboard Tab — Implementation Plan
+
+## Status
+
+Planned. Not started. This document is a self-contained build brief: a fresh
+Claude Code session can implement the feature from this file alone.
+
+## Goal
+
+Add an **ESS** tab to the OptiVolt web UI, positioned **between the EV tab and
+the Predictions tab**, that visualizes the home battery system the way the
+existing Home Assistant `ess_system` dashboard does — but rendered natively in
+OptiVolt with its own look and feel (Chart.js, `card`/`sidebar-label` styling,
+light/dark theme).
+
+The system has **two batteries** plus a Victron system view, so the tab must
+support **multiple batteries** generically (not hardcoded to two), driven by
+configuration with sensible defaults seeded for the current hardware.
+
+### Source dashboard being reproduced
+
+The Home Assistant dashboard (`.storage/lovelace.ess_system` in the
+`vervoto1/homeassistant` repo) contains, per battery:
+
+- **Cell voltage** charts (16 cells), one live snapshot and one 24h trend.
+- **Overview / settings** entities list (capacity setting, capacity remaining,
+  balancing on/off, balancing current, charging power, discharging power, total
+  voltage, state of charge, min/max cell voltage, pack current, calibration
+  numbers).
+- **Temperature monitoring** (4 cell temperature sensors + 1 MOSFET temp).
+- A combined **SoC development** chart across both batteries.
+
+Plus a **Victron system** card: ESS max charge current, battery power, DC bus
+current, DC bus voltage, system SoC.
+
+### Current hardware entities (defaults to seed)
+
+Two JK BMS units exposed through the `jk_bms` integration:
+
+- Battery 0 — name `Basen Green`, entity prefix `sensor.jk_bms_jk_bms_bms0_`
+- Battery 1 — name `Gobel Power`, entity prefix `sensor.jk_bms_jk_bms_bms1_`
+
+Per-battery entity suffixes (append to the prefix):
+
+- Cell voltage: `cell_voltage_1` … `cell_voltage_16`
+- Temperatures: `temperature_sensor_1` … `temperature_sensor_4`, plus
+  `temperature_sensor_5` labelled "MOS Temperature"
+- `state_of_charge`, `current`, `total_voltage`
+- `charging_power`, `discharging_power`
+- `total_battery_capacity_setting`, `capacity_remaining`
+- `min_cell_voltage`, `max_cell_voltage`
+- `balancing_current`
+- Binary: `binary_sensor.jk_bms_jk_bms_bms0_balancing`
+- Calibration numbers: `number.jk_bms_jk_bms_bms0_current_calibration`,
+  `number.jk_bms_jk_bms_bms0_voltage_calibration`
+
+Victron system entities (device id `c0619ab6bd28`):
+
+- `number.victron_mqtt_c0619ab6bd28_system_0_system_ess_max_charge_current`
+- `sensor.victron_mqtt_c0619ab6bd28_battery_512_battery_power`
+- `sensor.victron_mqtt_c0619ab6bd28_battery_512_battery_current`
+- `sensor.victron_mqtt_c0619ab6bd28_battery_512_battery_voltage`
+- `sensor.victron_mqtt_c0619ab6bd28_battery_512_battery_soc`
+
+---
+
+## Architecture context (what already exists in OptiVolt)
+
+Read these before starting; the feature plugs into existing plumbing.
+
+- **HA reading is already built.** `api/services/ha-client.ts` exposes:
+  - `fetchHaEntityState({ haUrl, haToken, entityId })` — single live entity via
+    the HA REST API. In add-on mode it transparently uses the supervisor proxy
+    (`http://supervisor/core` + `SUPERVISOR_TOKEN`).
+  - `fetchHaStats({ haUrl, haToken, entityIds, startTime, endTime, period })` —
+    long-term/short-term statistics via the HA WebSocket
+    `recorder/statistics_during_period` command. `period` accepts
+    `5minute` / `hour` / `day` / `month`. This is exactly what the source
+    dashboard's `statistics-graph` cards use.
+  - `api/services/ha-config.ts` resolves add-on vs standalone credentials
+    (`resolveHaHttpConfig`, `resolveHaWsConfig`). Reuse it; do not reinvent.
+- **HA route pattern.** `api/routes/ha.ts` already proxies
+  `GET /ha/entity/:entityId` to the browser. New ESS routes follow the same
+  shape (load settings, resolve HA config, call the client, map errors via
+  `toHttpError`).
+- **Settings are server-owned.** `api/types.ts` defines `Settings`;
+  `api/defaults/default-settings.json` holds defaults; `POST /settings`
+  deep-merges and persists to `DATA_DIR/settings.json`. Add an `essConfig`
+  object here.
+- **Front end is build-free ESM.** `app/index.html` + `app/main.js`, browser
+  modules under `app/src/`. Charts use the vendored Chart.js
+  (`app/vendor/chart.umd.js`, global `Chart`) via `renderChart(canvas, config)`
+  and `getBaseOptions(...)` in `app/src/charts/core.js`. The colour palette and
+  helpers (`toRGBA`, `dim`, `getBuyPriceColor`) live in `app/src/charts/colors.js`.
+- **Tabs.** Tab buttons live in the `<nav role="tablist">` in `app/index.html`;
+  panels are `<div role="tabpanel" id="panel-...">`. `setupTabSwitcher()` in
+  `app/main.js` builds a `tabs` array and crossfades panels. The Predictions tab
+  is initialized lazily in `boot()` via `initPredictionsTab()` — mirror that for
+  ESS so the tab does no HA I/O until first shown.
+
+### UI style tokens to reuse (from `app/index.html`)
+
+- Panel wrapper: `mx-auto w-full max-w-7xl px-4 py-8 grid gap-6 lg:grid-cols-3 panel-hidden`
+- Card: `<section class="card">` / `<div class="card">`
+- Card heading: `<h3 class="sidebar-label">…</h3>`
+- Chart wrapper: `<div class="h-80 w-full chart-wrap"><canvas …></canvas><div class="chart-empty">…</div></div>`
+- Stat tiles: `summary-panel`, `stat-label`, `stat-value`
+- Toggle: `<label class="toggle"><input type="checkbox"><span class="toggle-knob"></span>…</label>`
+- Inputs: `class="form-input"`
+- Tab button: copy an existing `<button id="tab-…" role="tab" aria-controls="panel-…">`
+  with the active/inactive class strings used by `setupTabSwitcher()`.
+
+---
+
+## Data model
+
+### `essConfig` (add to `Settings` in `api/types.ts`)
+
+```ts
+export interface EssBatteryConfig {
+  name: string;                       // display name, e.g. "Basen Green"
+  // Cell voltages: either an explicit list, or a prefix + count that expands to
+  // `${cellVoltagePrefix}${n}` for n in 1..cellCount.
+  cellVoltagePrefix?: string;         // e.g. "sensor.jk_bms_jk_bms_bms0_cell_voltage_"
+  cellCount?: number;                 // e.g. 16
+  cellVoltageEntities?: string[];     // explicit override, wins over prefix+count
+  // Temperatures: list of { entity, name }.
+  temperatureEntities?: { entity: string; name: string }[];
+  // Scalar entities (all optional; missing ones are simply not rendered).
+  socEntity?: string;
+  currentEntity?: string;
+  totalVoltageEntity?: string;
+  chargingPowerEntity?: string;
+  dischargingPowerEntity?: string;
+  capacitySettingEntity?: string;
+  capacityRemainingEntity?: string;
+  minCellVoltageEntity?: string;
+  maxCellVoltageEntity?: string;
+  balancingBinaryEntity?: string;
+  balancingCurrentEntity?: string;
+  extraEntities?: { entity: string; name?: string }[]; // e.g. calibration numbers
+}
+
+export interface EssSystemConfig {
+  name?: string;                      // e.g. "Victron system"
+  maxChargeCurrentEntity?: string;
+  batteryPowerEntity?: string;
+  batteryCurrentEntity?: string;
+  batteryVoltageEntity?: string;
+  socEntity?: string;
+  extraEntities?: { entity: string; name?: string }[];
+}
+
+export interface EssConfig {
+  enabled: boolean;
+  batteries: EssBatteryConfig[];
+  system?: EssSystemConfig;
+  historyWindowHours: number;         // default 24
+  historyPeriod: '5minute' | 'hour';  // default '5minute'
+  refreshIntervalSeconds: number;     // live state poll cadence, default 30
+}
+```
+
+Add `essConfig?: EssConfig;` to `Settings`.
+
+### Defaults (`api/defaults/default-settings.json`)
+
+Seed `essConfig` with the two batteries and the Victron system from the
+hardware list above so the tab works out of the box, while remaining fully
+editable. Use the `cellVoltagePrefix` + `cellCount: 16` form to keep it compact.
+`temperature_sensor_5` carries the display name `MOS Temperature`.
+
+### Validation (`api/services/settings-schema.ts`)
+
+Add an `essConfig` validator consistent with the other optional config blocks:
+`enabled` boolean; `batteries` an array of objects with a required string
+`name`; numeric `historyWindowHours` / `refreshIntervalSeconds`; `historyPeriod`
+one of the allowed enum values. Be permissive about entity-id strings (any
+non-empty string), since they are user-specific.
+
+---
+
+## Backend
+
+### New service: `api/services/ess-service.ts`
+
+Two functions, both pure orchestration over `ha-client.ts`:
+
+- `getEssState(settings)`:
+  1. Resolve the enabled `essConfig`; throw `HttpError(422)` if HA is not
+     configured (mirror `api/routes/ha.ts`).
+  2. Expand each battery's cell-voltage entity list (prefix+count or explicit).
+  3. Collect **all** scalar + cell + temperature entity ids across batteries and
+     system into one set, fetch their live states **concurrently** with
+     `Promise.allSettled` over `fetchHaEntityState`. Tolerate per-entity
+     failures (return `null` value for that entity) so one missing sensor never
+     blanks the whole tab.
+  4. Shape into a structured response:
+
+     ```ts
+     interface EssStateResponse {
+       batteries: {
+         name: string;
+         cells: { entity: string; value: number | null }[];
+         temperatures: { entity: string; name: string; value: number | null }[];
+         scalars: Record<string, { entity: string; value: number | null; unit?: string }>;
+         extras: { entity: string; name: string; value: string | null; unit?: string }[];
+       }[];
+       system?: { name: string; scalars: Record<string, …>; extras: […] };
+       fetchedAtMs: number;
+     }
+     ```
+
+- `getEssHistory(settings, { hours, period })`:
+  1. Build the entity-id list for trend charts: all cell-voltage entities, all
+     temperature entities, and all per-battery SoC entities.
+  2. Compute `startTime = new Date(Date.now() - hours*3600_000).toISOString()`.
+  3. Call `fetchHaStats({ …, entityIds, startTime, period })`.
+  4. Return the raw per-entity reading arrays keyed by entity id, plus the
+     `hours`/`period` echoed back. (The client maps these into Chart.js series.)
+
+### New route: `api/routes/ess.ts`
+
+- `GET /ess/state` → `getEssState(loadSettings())`.
+- `GET /ess/history?hours=24&period=5minute` → `getEssHistory(...)` with query
+  parsing + clamping (`hours` 1..168, `period` whitelist).
+- Optional, **phase 2**: `POST /ess/max-charge-current` to write the Victron ESS
+  max charge current. This requires an HA service call (`number/set_value`),
+  which OptiVolt does not currently issue. Leave the field **read-only in
+  phase 1**; document the service-call approach in a code comment and defer.
+
+Mount in `api/app.ts` next to the other routers: `app.use('/ess', essRouter)`.
+
+### Browser API wrappers (`app/src/api/api.js`)
+
+Add `getEssState()` and `getEssHistory({ hours, period })` using the existing
+`getJson` helper from `app/src/api/client.js`.
+
+---
+
+## Front end
+
+### `app/index.html`
+
+1. **Tab button** — insert a new `<button id="tab-ess" role="tab"
+   aria-controls="panel-ess">` in the `<nav>` **between `tab-ev` and
+   `tab-predictions`**. Use the inactive class string (copy from `tab-ev`) and a
+   battery icon SVG, e.g. a Heroicons/MDI battery glyph:
+
+   ```html
+   <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0"
+        viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+     <path d="M15.67 4H14V2h-4v2H8.33C7.6 4 7 4.6 7 5.33v15.33C7 21.4 7.6 22 8.33 22h7.33c.74 0 1.34-.6 1.34-1.33V5.33C17 4.6 16.4 4 15.67 4z"/>
+   </svg>
+   <span class="hidden sm:inline">ESS</span>
+   ```
+
+2. **Panel** — add `<div id="panel-ess" role="tabpanel"
+   aria-labelledby="tab-ess" class="mx-auto w-full max-w-7xl px-4 py-8 grid gap-6 lg:grid-cols-3 panel-hidden">`
+   after the EV panel and before the Predictions panel. Inside, lay out (all
+   using `card` / `sidebar-label` / `chart-wrap` / `summary-panel`):
+
+   - **Per battery** (rendered dynamically by JS, but provide a container the JS
+     clones a template into, or build entirely in JS):
+     - Overview card: a definition-list of the scalar values (SoC, capacity
+       remaining / setting, total voltage, pack current, charging power,
+       discharging power, min/max cell voltage, balancing on/off + balancing
+       current, plus any `extraEntities`). Use `summary-panel` + `stat-label` /
+       `stat-value` tiles, or a simple two-column rows layout.
+     - Cell-voltage **snapshot** chart: 16-bar bar chart of current cell
+       voltages (one canvas).
+     - Cell-voltage **trend** chart: line chart, 16 series, 24h of `5minute`
+       stats (legend hidden, matching the source dashboard).
+     - Temperature **trend** chart: line chart, 5 series (legend shown).
+   - **Combined SoC development** card spanning full width
+     (`lg:col-span-3`): line chart with one series per battery.
+   - **Victron system** card: scalar tiles for battery power, DC bus
+     current/voltage, system SoC, and ESS max charge current (read-only value
+     in phase 1).
+   - Each chart canvas wrapped with a `.chart-empty` placeholder (copy the SVG
+     bars markup from the optimizer "Power flows" card) shown until data loads.
+
+### `app/src/ess-tab.js` (new module)
+
+- `export function initEssTab()`:
+  - Lazy init guard (run once). Fetch `getEssState()` and `getEssHistory()` in
+    parallel; render cards + charts. Render an error/empty state if HA is not
+    configured (catch the 422 and show a friendly message in the panel, do not
+    throw — match how EV settings tolerate missing HA).
+  - Build per-battery card DOM dynamically from the state response so it scales
+    to N batteries.
+  - Start a refresh interval (`essConfig.refreshIntervalSeconds`) that re-fetches
+    **state** (cheap) while the ESS tab is the active panel; pause when hidden.
+    Re-fetch **history** on tab (re)activation, not every interval.
+- Charts via `renderChart(canvas, { type, data, options })`:
+  - Snapshot bars: `type: 'bar'`, x = `Cell 1..16`, single dataset, colour from
+    palette (e.g. a battery-blue from `SOLUTION_COLORS.soc`).
+  - Trend lines: build the time axis from the stats timestamps with
+    `buildTimeAxisFromTimestamps(...)` and `getBaseOptions(...)` from
+    `app/src/charts/core.js`. 16 thin lines, `pointRadius: 0`, legend hidden.
+  - Temperature: same, legend shown, y-axis 0..60 to match the source.
+  - SoC development: one line per battery, y `0..100`, unit `%`.
+  - Use `toRGBA(...)` / `dim(...)` for fills; generate 16 distinguishable cell
+    colours by rotating hue (a small helper) since the palette has no 16-colour
+    ramp.
+
+### `app/main.js`
+
+- Import `initEssTab` from `./src/ess-tab.js`.
+- Register the ESS tab in the `tabs` array inside `setupTabSwitcher()`:
+  `{ tab: document.getElementById('tab-ess'), panel: document.getElementById('panel-ess') }`.
+  (The `.filter(t => t.tab && t.panel)` guard already there means a missing
+  element won't crash.)
+- Wire lazy init: call `initEssTab()` the first time the ESS tab is activated
+  (add a small per-tab "activated once" hook in `activateTab`, or call it from
+  the `tab-ess` click handler). Do **not** init during `boot()` — keep startup
+  free of ESS HA traffic.
+
+### `app/src/state.js` element registry
+
+If the project funnels DOM lookups through `getElements()` in
+`app/src/ui-binding.js` / `state.js`, register the new ESS elements there for
+consistency. The dynamically-built per-battery DOM can live entirely inside
+`ess-tab.js` without registry entries.
+
+---
+
+## Phases
+
+| Phase | Scope | Output |
+|-------|-------|--------|
+| 1 | `essConfig` type + defaults + schema validation | Settings round-trips `essConfig` |
+| 2 | `ess-service.ts` + `/ess/state` route + browser wrapper | `GET /ess/state` returns live snapshot |
+| 3 | `/ess/history` route + browser wrapper | `GET /ess/history` returns stats series |
+| 4 | ESS tab button + panel + `main.js` wiring (renders state only) | Tab visible between EV and Predictions; overview cards + snapshot bars populate |
+| 5 | Trend + temperature + SoC charts from history | All charts render and match the source dashboard intent |
+| 6 | Refresh interval, empty/error states, dark-mode polish | Auto-refresh while visible; graceful when HA missing |
+| 7 (optional) | ESS settings card in Settings tab (edit batteries/entities) | Multi-battery editable in UI |
+| 8 (optional) | Writable ESS max charge current via HA `number/set_value` | Setpoint adjustable from OptiVolt |
+
+Phases 1–6 deliver the feature as requested. 7–8 are enhancements.
+
+---
+
+## Testing
+
+Follow `AGENTS.md` PR/testing notes. Run `npm run typecheck`, `npm run lint`
+(it lints `.md`/`.css` too), and `npm run test:run`.
+
+- **Service tests** (`tests/api/ess-service.test.js`): mock `ha-client.ts`
+  (`fetchHaEntityState`, `fetchHaStats`) and assert: cell-prefix expansion;
+  concurrent fetch; per-entity failure tolerance (one rejected entity → `null`
+  value, others still populated); correct entity-id set passed to
+  `fetchHaStats`; `startTime` derived from `hours`.
+- **Route tests** (`tests/api/ess-routes.test.js`, supertest): 200 shape for
+  `/ess/state` and `/ess/history`; 422 when HA unconfigured; query clamping on
+  `hours`/`period`.
+- **Browser tests** (`tests/app/ess-tab.test.js`, jsdom): given a mocked state
+  response, `initEssTab()` builds N battery cards; given a 422 it shows the
+  empty state without throwing; tab registers in the switcher and is positioned
+  between EV and Predictions in the nav DOM order.
+
+No version bump is required unless `optivolt/` add-on files change (they do not
+for this feature) — see the versioning rules in `CLAUDE.md`. If a release is
+cut, bump `package.json`, `package-lock.json`, `optivolt/config.yaml`, and
+`CHANGELOG.md` together.
+
+---
+
+## Acceptance criteria
+
+- A new **ESS** tab appears in the nav, ordered Optimizer · EV · **ESS** ·
+  Predictions · Settings.
+- The tab shows **both** batteries (and scales to more from config) with cell
+  voltages (snapshot + 24h trend), temperatures (24h trend), and an overview of
+  SoC / power / voltage / current / balancing.
+- A combined SoC-development chart and a Victron system card are present.
+- Visuals use OptiVolt's `card` / `sidebar-label` / Chart.js styling and respect
+  light/dark theme — not embedded HA cards or iframes.
+- Battery/entity mapping is **configuration-driven** via `essConfig`, defaulting
+  to the current `Basen Green` + `Gobel Power` + Victron hardware.
+- When HA is unconfigured/unreachable, the tab degrades gracefully (empty state,
+  no crash). Startup does no ESS HA traffic until the tab is first opened.
+- `npm run typecheck`, `npm run lint`, and `npm run test:run` pass.

--- a/plans/ess-dashboard-tab-plan.md
+++ b/plans/ess-dashboard-tab-plan.md
@@ -214,6 +214,16 @@ Add an `essConfig` validator consistent with the other optional config blocks:
 one of the allowed enum values. Be permissive about entity-id strings (any
 non-empty string), since they are user-specific.
 
+> **CRITICAL — add `essConfig` to the deep-merge list.** `settings-store.ts` only
+> deep-merges the *known* nested blocks (`dataSources`, `shoreOptimizer`,
+> `pvCurtailment`, ~`settings-store.ts:25`); everything else goes through a
+> shallow `{...defaults, ...settings}`. A nested `essConfig` left out of that list
+> is **shallow-replaced**, so a future ESS settings UI (phase 7) that PATCHes a
+> single field like `historyWindowHours` will **wipe `batteries`** and the rest.
+> Add an explicit `mergedEssConfig` (deep-merge defaults + persisted, and
+> per-battery array handling) alongside the existing blocks. Test: PATCH one
+> scalar field, assert `batteries` survives.
+
 ---
 
 ## Backend
@@ -224,7 +234,11 @@ Two functions, both pure orchestration over `ha-client.ts`:
 
 - `getEssState(settings)`:
   1. Resolve the enabled `essConfig`; throw `HttpError(422)` if HA is not
-     configured (mirror `api/routes/ha.ts`).
+     configured. **Do NOT "mirror `/ha/entity`"** — that route only checks
+     `haUrl` and not the token (`ha.ts:17`) and will attempt a doomed REST call
+     when no token exists. Call `resolveHaHttpConfig(haUrl, haToken)` (for the
+     bulk-state REST path) / `resolveHaWsConfig` (for stats/history WS) directly
+     and return 422 when they return `null`, so a missing token fails fast.
   2. Expand each battery's cell-voltage entity list (prefix+count or explicit).
   3. Collect **all** scalar + cell + temperature entity ids across batteries and
      system into one set, then fetch their live states.
@@ -284,8 +298,13 @@ Two functions, both pure orchestration over `ha-client.ts`:
   >    using `history/history_during_period` (REST `GET /api/history/period/...`,
   >    or the WS `history/history_during_period` command) for entities that lack
   >    statistics. `getEssHistory` chooses per entity: statistics where available
-  >    (cheap, pre-aggregated), raw history otherwise. Raw history is higher
-  >    volume — clamp the window and/or downsample client-side.
+  >    (cheap, pre-aggregated), raw history otherwise.
+  > 3. **Downsample on the server, not the client.** Raw `history_during_period`
+  >    can return thousands of points per sensor × ~40 sensors; shipping that to
+  >    the browser and downsampling there is too late (the payload is already
+  >    huge). Cap/bucket per entity **server-side** in `getEssHistory` (e.g. to
+  >    the requested `period` granularity, ~N points max) so this never becomes
+  >    the heaviest endpoint in the app on recorder-heavy installs.
   >
   > This is the headline risk for the tab: without it, the cell-voltage trends —
   > the main reason the dashboard exists — may ship blank.
@@ -364,8 +383,17 @@ Add `getEssState()` and `getEssHistory({ hours, period })` using the existing
   - Build per-battery card DOM dynamically from the state response so it scales
     to N batteries.
   - Start a refresh interval (`essConfig.refreshIntervalSeconds`) that re-fetches
-    **state** (cheap) while the ESS tab is the active panel; pause when hidden.
-    Re-fetch **history** on tab (re)activation, not every interval.
+    **state** while the ESS tab is the active panel; re-fetch **history** on tab
+    (re)activation, not every interval.
+    - **Explicit interval lifecycle (don't leak timers).** `activeIndex` only
+      flips *after* the 200 ms crossfade transition (`main.js:76`), and the
+      switcher is closed over inside `setupTabSwitcher`. Keying "is the ESS tab
+      active?" off DOM hidden state or click handlers leaks polling after rapid
+      tab switches. Own a single `setInterval` handle in `ess-tab.js`; start it on
+      ESS activation and **`clearInterval` on deactivation** (expose a
+      `deactivateEssTab()` the switcher calls, or subscribe to an explicit tab
+      lifecycle event). Test: switching away clears the interval (no further
+      `getEssState` calls).
 - Charts via `renderChart(canvas, { type, data, options })`:
   - Snapshot bars: `type: 'bar'`, x = `Cell 1..16`, single dataset, colour from
     palette (e.g. a battery-blue from `SOLUTION_COLORS.soc`).

--- a/plans/ev-native-charging-plan.md
+++ b/plans/ev-native-charging-plan.md
@@ -220,53 +220,125 @@ Translate the new settings into `SolverConfig`: resolve `evStartTime` /
 SoC, opportunistic levels, and continuity through. Effective opportunistic cap =
 `max(targetSoc, opportunisticLevel, type2Level if enabled)` clamped to 100%.
 
+> **CRITICAL — reconcile with the existing target clamp.** Today
+> `config-builder.ts:131` does
+> `achievableTargetWh = Math.min(requestedTargetWh, initialWh + maxChargeable_Wh, capacityWh)`
+> and passes the *clamped* value as `evTargetSoc_percent`. That clamp exists only
+> to keep today's **hard** `c_ev_target` equality feasible. Once the target
+> becomes **soft** (below), this clamp becomes harmful: it silently lowers the
+> target before the LP sees it, so `ev_target_shortfall` reads ~0 and
+> `ev_target_met` reports "met" while the car is below the user's *requested*
+> SoC. **Change the clamp to a capacity-only cap**
+> (`Math.min(requestedTargetWh, capacityWh)`) and let the soft constraint carry
+> feasibility. Pick exactly one feasibility mechanism — clamp **or** soft target,
+> not both.
+>
+> **Guard the window.** After resolving slots, require `evStartSlot < depSlot`.
+> If the window is empty (start ≥ departure, or departure already elapsed →
+> `departureTimeToSlot` returns 0), disable EV planning for this solve rather
+> than emitting masks that zero every slot (which, combined with the cardinality
+> bound below, would make the model infeasible). Log the reason.
+
 ### `lib/build-lp.ts`
 
 1. **Earliest-start + ready window mask.** Force `ev_charge_t = 0` for
-   `t < evStartSlot` and `t > departureSlot` (the upper bound likely exists; add
-   the lower bound).
+   `t < evStartSlot` and `t ≥ depSlot`. The upper-bound side already exists
+   implicitly (the SoC target lives at `depSlot - 1`); add the lower bound by
+   pinning the flow bounds to 0 (`gridToEv`/`pvToEv`/`batteryToEv` upper bound 0)
+   and forcing `ev_on_t = 0` for masked slots, so the cardinality bound (#3a)
+   counts only reachable slots.
 2. **Price-limit mask.** When `evApplyPriceLimit`, force `ev_charge_t = 0` for
-   every slot whose import price exceeds `evMaxPrice_cents_per_kWh`. (Mask total
-   EV charge, not just `grid_to_ev`, to mirror the integration, which suppresses
-   charging entirely in over-limit slots.)
-3. **Soft target SoC.** Replace the hard "EV SoC ≥ target at departure" equality
-   with a soft constraint: introduce a non-negative shortfall variable
-   `ev_target_shortfall` with `ev_soc_departure + ev_target_shortfall ≥ target`
-   and add `BIG_PENALTY × ev_target_shortfall` to the objective. With a price
-   mask in place this keeps the model **feasible** when cheap slots are
-   insufficient, and the optimizer still hits the target whenever it can. Keep
-   the penalty well above any realistic energy price so target is honored unless
-   physically/price-mask blocked.
-4. **Minimum-SoC floor (hard).** Add `ev_soc_t ≥ evMinSoc_percent` for all slots
-   at/after the first slot in which the floor is physically reachable from the
-   starting SoC at max power. Min SoC is a safety floor and is **not** subject to
-   the price mask — exempt min-SoC-driven charging slots from the mask (e.g. a
-   dedicated `ev_floor_charge_t` term, or relax the mask until the floor is met).
-5. **Opportunistic value band.** For SoC above target up to the opportunistic
-   cap, add a small **negative cost** (reward) on stored EV energy valued at the
-   opportunistic price threshold, so the optimizer fills that band only when it
-   is cheap. Implement as a marginal value on the EV SoC band above target, not
-   as a constraint. Type 2 is a second band with its own (higher) cap; value it
-   at most the same or a configurable threshold.
-6. **Continuity penalty (MILP, optional / phase 2).** OptiVolt already uses MILP
-   binaries (CV phase). Reuse the EV on/off binary `ev_on_t` and add transition
-   variables capturing `ev_on_t XOR ev_on_{t-1}`; penalize the count of
-   transitions with a small objective weight when `evContinuous`. This biases the
-   solver toward one contiguous block without hard-forcing it.
+   every slot whose import price exceeds `evMaxPrice_cents_per_kWh` — pin the
+   three EV flow bounds to 0 and `ev_on_t = 0` (same mechanism as #1). Mask
+   *total* EV charge, not just `grid_to_ev`, to mirror the integration.
+   **Exception:** slots needed by the min-SoC floor (#4) are never masked.
+3. **Soft target SoC.** Replace the hard `c_ev_target` (`build-lp.ts:445`,
+   `ev_soc_{depSlot-1} ≥ evTargetWh`) with a soft constraint: add a non-negative
+   `ev_target_shortfall` and the constraint
+   `ev_soc_{depSlot-1} + ev_target_shortfall ≥ evTargetWh`, plus
+   `BIG_PENALTY × ev_target_shortfall` in the objective. `BIG_PENALTY` must sit
+   **above** the largest per-Wh import cost in the horizon but **below** the
+   `softMinSocPenalty`/`TIEBREAK` scales so it doesn't distort battery economics —
+   reuse the existing magnitude discipline (the TIEBREAK ladder is `5e-7…4e-6`;
+   the shortfall penalty is a *large* coefficient, e.g. `100` c€/Wh, far above any
+   realistic price). Surface `ev_target_shortfall` in the solution so
+   `parse-solution` can derive `ev_target_met`.
+
+   3a. **Remove/recompute the cardinality lower bound.** `c_ev_min_on`
+   (`build-lp.ts:462`, `Σ ev_on_t ≥ kMin`) was derived from the *hard* deficit and
+   assumes every slot is available. With a soft target and/or any mask it can
+   force more on-slots than exist among reachable slots → **infeasible LP** (the
+   exact failure the soft target is meant to prevent). Fix: when a mask or the
+   soft target is active, either (a) drop `c_ev_min_on` entirely, or (b) recompute
+   `kMin = min(kMin, count(reachable, non-masked slots in [evStartSlot, depSlot)))`.
+   Prefer (b) only if you still want the relaxation-tightening; (a) is simpler and
+   safe. This is the single highest-risk LP interaction — cover it with the
+   regression test in Testing.
+4. **Minimum-SoC floor (hard, MILP-gated, mask-exempt).** A *static* mask cannot
+   express "exempt the floor slots" because the floor slots aren't known at build
+   time. Use a MILP indicator instead:
+   - Add `ev_soc_t ≥ evMinFloorWh` for all `t` at/after the first slot the floor
+     is physically reachable from `evInitialWh` at max power (a hard floor, like
+     today's soc bounds — independent of price).
+   - Introduce a binary `ev_floor_active_t` and a separate flow term
+     `ev_floor_charge_t` (AC into the charger) that is **excluded from the price
+     mask**. Bound `ev_floor_charge_t = 0` whenever the floor is already satisfied
+     (`ev_soc_{t-1} ≥ evMinFloorWh` ⇒ via the indicator), and route it into
+     `c_ev_soc_t` exactly like `grid_to_ev` (AC, `evChargeWhPerW` factor).
+   - The floor charge competes with nothing on price (it's a safety obligation),
+     so it carries only the normal import cost in the objective, no mask, no
+     opportunistic reward.
+
+   ```
+   PRICE-MASK vs MIN-SOC-FLOOR (decision)
+     slot t price > limit?
+        │ no ──► normal masked planning (ev_charge_t free, c_ev_target soft)
+        └ yes ─► ev_charge_t = 0  (masked)
+                    │
+                    └─ but ev_soc_{t-1} < evMinFloorWh ?
+                          │ no ──► stays masked (0)
+                          └ yes ─► ev_floor_charge_t > 0 allowed (mask-exempt,
+                                    pays import cost, bounded by evMaxPow_W)
+   ```
+5. **Opportunistic value band (bounded reward).** For SoC above target up to the
+   opportunistic cap, add a small **negative cost** on stored EV energy in that
+   band. The reward magnitude must be **strictly less** than the marginal import
+   cost of the cheapest slot that could fill the band, in every slot — otherwise
+   the solver fills to the cap regardless of price ("opportunistic" degenerates to
+   "always fill"). Concretely: value the band at the *opportunistic price
+   threshold minus an epsilon*, and verify the sign/magnitude ordering holds
+   against `BIG_PENALTY` (shortfall), `batteryCost_cents`, and the TIEBREAK ladder.
+   Type 2 is a second, higher band with its own cap valued at most the same.
+   Implement as a marginal value on the EV SoC band above target (segmented SoC
+   variable), not a constraint.
+6. **Continuity penalty (MILP, optional / phase 7).** Reuse `ev_on_t` and add
+   transition variables capturing `ev_on_t XOR ev_on_{t-1}`; penalize the
+   transition count with a small objective weight when `evContinuous`. Biases
+   toward one contiguous block without hard-forcing it.
 
 ### `lib/parse-solution.ts`
 
-Surface the new outputs: `ev_soc_percent` already exists; add `ev_target_met`
-(boolean from shortfall ≈ 0) and ensure `ev_charge_mode` reflects planned vs
-opportunistic vs floor (`planned` / `opportunistic` / `min_soc`). The
-override-driven modes (`low_price`, `low_soc`, `keep_on`) are assigned in the
-runtime layer, not here.
+> **CRITICAL — do NOT overload `ev_charge_mode`.** `ev_charge_mode` already
+> exists as the **hardware-actuation hint** enum `EvChargeMode`
+> (`off | fixed | solar_only | solar_grid | max`, `lib/types.ts:136`, computed in
+> `parse-solution.ts:127`/`evChargeMode()`), and it is **consumed by
+> `lib/dess-mapper.ts`** to pick charger amps/strategy. Writing planning labels
+> (`planned`/`opportunistic`/`min_soc`/…) into it would silently break DESS
+> mapping.
+
+Add a **separate** field `ev_plan_mode: 'planned' | 'opportunistic' | 'min_soc'`
+(planning semantics), leave `ev_charge_mode` untouched, and add `ev_target_met`
+(boolean from `ev_target_shortfall ≈ 0`). The override-driven plan modes
+(`low_price`, `low_soc`, `keep_on`) are assigned in the runtime layer and live on
+the decision object, not on the plan row.
 
 ### `lib/dess-mapper.ts`
 
 No structural change required — it already consumes EV flows and applies EV
-discharge constraints. Verify the soft-target change does not alter the mapping
-contract (the mapper reads realized `ev_charge`, not the target).
+discharge constraints. **Verify two things:** (1) the soft-target change does not
+alter the mapping contract (the mapper reads realized `ev_charge`, not the
+target), and (2) `ev_charge_mode` semantics are unchanged (per the
+`ev_plan_mode` split above) so DESS amp/strategy selection is unaffected.
 
 ---
 
@@ -381,6 +453,17 @@ Per `AGENTS.md`: `npm run typecheck`, `npm run lint`, `npm run test:run`.
   when cheap slots are insufficient and still hits target when they are
   sufficient; min-SoC floor reached at the earliest feasible slot and exempt
   from the price mask; opportunistic band only fills below its price threshold.
+  - **CRITICAL regression — feasibility under mask + cardinality bound.** Build
+    a case where the price mask zeros enough slots that fewer than the old `kMin`
+    remain, and assert the LP is **feasible** (proves the `c_ev_min_on` fix in
+    LP-change #3a). Without this test the soft-target work can ship a solver that
+    returns "infeasible" in production.
+  - **`ev_plan_mode` vs `ev_charge_mode`.** Assert `ev_charge_mode` retains its
+    hardware-hint values and `ev_plan_mode` carries planning labels — guards the
+    enum-collision split.
+  - **No false "target met".** With the requested target above what's reachable,
+    assert `ev_target_met === false` and `ev_target_shortfall > 0` (proves the
+    `achievableTargetWh` clamp no longer masks the shortfall).
 - **`ev-decision-service`** (`tests/api/`): priority ordering
   (low-SoC > low-price > min-SoC floor > planned); plug-status gating; mode +
   power returned; tolerant of missing HA (falls back to planned).
@@ -391,6 +474,15 @@ Per `AGENTS.md`: `npm run typecheck`, `npm run lint`, `npm run test:run`.
   HA error / missing plan / restart); plug-gating; `evFailSafeMode: 'stop'`
   issues a single `turn_off` on sustained error; `evActuationPaused` suspends
   control; mock `callHaService`.
+  - **Boot seeding (regression).** First tick after start reads observed charger
+    state, seeds `lastCommand`, and issues **no** write (no blip); tick 2 applies
+    a plan change. Asserts the "clean startup" semantics.
+  - **No plan source.** With `getLastPlan()` null / auto-calculate disabled, the
+    actuator makes no write and reports `status: 'no_plan_source'`.
+  - **Stale plug status.** `evPlugSensor` returning `unavailable` produces a
+    no-write (uncertain), NOT a `turn_off`.
+  - **Contention detection.** Observed state diverging from commanded for N ticks
+    flags contention (and auto-pauses if configured).
 - **Browser** (`tests/app/`): new settings inputs hydrate and snapshot; mode
   badge renders per `/ev/current`; `haSchedule` source hides native controls.
 
@@ -436,10 +528,11 @@ callHaService({ haUrl, haToken, domain, service, target, data }):
 ```
 
 Reuse `resolveHaHttpConfig` for credentials: in add-on mode it posts through the
-supervisor proxy (`http://supervisor/core` + `SUPERVISOR_TOKEN`); the add-on
-manifest `optivolt/config.yaml` must declare `homeassistant_api: true` so the
-supervisor allows service calls. Keep the function generic — the EV actuator is
-just its first caller.
+supervisor proxy (`http://supervisor/core` + `SUPERVISOR_TOKEN`). The add-on
+manifest **already declares `homeassistant_api: true`** (`optivolt/config.yaml:19`),
+so the supervisor already allows service calls — no manifest change is needed.
+Keep the function generic — the EV actuator is just its first caller (the ESS
+plan's writable max-charge-current, ESS phase 8, is the second; build this once).
 
 ### Actuator service (`api/services/ev-actuator-service.ts`)
 
@@ -448,37 +541,78 @@ server start the same way `api/services/auto-calculate.ts` is wired:
 
 1. Every `evControlIntervalSeconds` (default 60), compute the effective decision
    with `computeEvDecision(settings, getLastPlan())` from the override layer.
-2. Gate first: if `!evActuationEnabled` or `evActuationPaused`, do nothing. If
-   the EV is not plug-connected, ensure the charger is off (subject to fail-safe)
-   and return.
+
+   > **Dependency — actuation needs a current plan, which needs auto-calculate.**
+   > `getLastPlan()` is populated only by `auto-calculate.ts`, which is opt-in
+   > (`if (!config?.enabled) return;`). If a user enables `evActuationEnabled`
+   > but not `autoCalculate`, `getLastPlan()` is `null` forever and (per
+   > fail-safe) the charger is never driven — a **silent** dead feature. Surface
+   > this: on actuator start, if auto-calculate is disabled, log a warning and
+   > report it in `GET /ev/actuation` (`status: 'no_plan_source'`). Optionally
+   > trigger a solve from the actuator. Add a startup-validation test.
+2. Gate first: if `!evActuationEnabled` or `evActuationPaused`, do nothing.
+   Plug-status gating with **staleness awareness**: read `evPlugSensor`; if the
+   value is `unavailable`/`unknown` (a transient HA hiccup), treat it as
+   **uncertain → no write** (per fail-safe), NOT as "unplugged → turn off".
+   Only a *fresh, definite* not-connected state ensures the charger is off
+   (subject to fail-safe).
 3. Drive the charger **idempotently** — only issue a service call when the desired
    state differs from the last command OptiVolt sent (track last command in
    memory):
    - on/off via `callHaService('switch', is_charging ? 'turn_on' : 'turn_off', { entity_id: evChargerSwitchEntity })`
    - charge current, if `evChargerCurrentEntity` is set, via
      `callHaService('number', 'set_value', { entity_id: evChargerCurrentEntity }, { value: ev_charge_A })`
-4. Record the last actuation (mode, command, value, timestamp, ok/error) in
-   memory for `GET /ev/actuation` and the EV-tab badge.
+4. **Single-owner contention detection.** Each tick, compare the *observed*
+   charger state against the state OptiVolt last commanded. If they diverge for
+   N consecutive ticks despite OptiVolt not writing (something else is toggling
+   the charger), log it and (optionally) auto-pause — this is the only signal
+   OptiVolt has that a second controller is fighting it.
+5. Record the last actuation (mode, command, value, observed-vs-commanded,
+   timestamp, ok/error) in memory for `GET /ev/actuation` and the EV-tab badge.
 
 Add a small `GET /ev/actuation` route returning that last-actuation record for
 observability.
 
+> **Cadence note.** The actuator ticks every ~60 s on *live* SoC/price but the
+> planned fallback (`getLastPlan()`) is refreshed only every ~15 min and is
+> replaced wholesale with no locking. That's acceptable (the override layer
+> reacts live; the plan is a slow baseline), but document that a tick may read a
+> plan up to one interval stale, and ensure reads of `getLastPlan()` tolerate it
+> being swapped mid-tick (snapshot the reference once per tick).
+
 ### Fail-safe and ownership rules
 
-- **Single owner.** When `evActuationEnabled`, OptiVolt is the **only** writer to
-  the charger entities. The EV Smart Charging integration must be
-  disabled/removed so the two never fight (the cutover steps enforce this).
+- **Single owner (procedural, with a detection backstop).** When
+  `evActuationEnabled`, OptiVolt is the *intended* only writer to the charger
+  entities. Nothing in OptiVolt can technically *prevent* a second controller
+  (the EV Smart Charging integration, or a stray HA automation) from also
+  toggling the switch — idempotency only stops OptiVolt from spamming, it cannot
+  stop the other writer. The cutover steps are the primary guard; the
+  contention-detection in the actuator loop (step 4) is the backstop that surfaces
+  a missed cutover instead of letting the charger flap silently.
+- **Don't fight the battery-protection automation.** The Tesla draws through the
+  Victron inverter, and an independent JK BMS / Victron *max-charge-current*
+  automation may throttle charge current for battery protection (see
+  `CLAUDE.md` and the ESS dashboard plan). When that automation caps current,
+  OptiVolt will command the charger on at planned amps and see SoC not rising;
+  the low-SoC override must **not** escalate into a fight (e.g. cap commanded
+  current to the BMS-allowed value if `evChargerCurrentEntity` is driven, and
+  treat "on but not charging" as the BMS's call, not a fault).
 - **Fail-safe = no write on uncertainty.** On any error (HA unreachable, missing
-  live SoC/price, no current plan) or right after an OptiVolt restart, the
-  actuator makes **no** charger write — the charger holds its last physical
-  state. Never leave the charger forced-on as a side effect of a failure.
-  `evFailSafeMode: 'stop'` is an opt-in stricter mode that issues a single
-  `turn_off` on sustained error.
+  live SoC/price, no current plan, stale plug status) the actuator makes **no**
+  charger write — the charger holds its last physical state. Never leave the
+  charger forced-on as a side effect of a failure. `evFailSafeMode: 'stop'` is an
+  opt-in stricter mode that issues a single `turn_off` on sustained error.
 - **Respect manual control.** A user toggling the charger by hand should not be
   instantly reverted; `evActuationPaused` suspends OptiVolt control, and the
   idempotent design avoids spamming writes.
-- **Clean startup.** On boot, read the charger's current state before the first
-  command so the first tick is idempotent and does not blip the charger.
+- **Clean startup (precise semantics).** "No write on restart" and "idempotent"
+  must not contradict each other. On boot: **tick 1** reads the charger's current
+  observed state and *seeds* `lastCommand = observed` and writes **nothing**
+  (no blip). From **tick 2** onward, normal idempotent writes apply (write only
+  when desired ≠ `lastCommand`). This means a plan change that occurred during the
+  downtime *is* applied on tick 2 — "no write on restart" scopes to the first
+  tick only, it is not "never write until the user changes something".
 
 ### Cutover — retire the integration
 

--- a/plans/ev-native-charging-plan.md
+++ b/plans/ev-native-charging-plan.md
@@ -16,11 +16,19 @@ OptiVolt currently lacks — notably **low-price charging** and **low-SoC
 charging** — plus price limit, minimum SoC, opportunistic charging, continuous
 charging, keep-on, and an earliest-start window.
 
-OptiVolt continues to **plan only**; Home Assistant continues to **actuate** the
-physical charger (Tesla Wall Connector, 11 kW). OptiVolt exposes the plan and
-the live decision over `/ev/*`; an HA automation drives the charger from it (see
-the Appendix). This preserves OptiVolt's design rule: "HA controls the physical
-charger, OptiVolt only plans."
+OptiVolt becomes the **sole owner** of EV charging: it plans, applies the live
+overrides, **and actuates the physical charger** (Tesla Wall Connector, 11 kW)
+directly via Home Assistant service calls. The goal is to **retire the EV Smart
+Charging integration entirely** — OptiVolt does both the deciding and the
+driving. It still exposes the plan and live decision over `/ev/*` for
+observability. Keeping OptiVolt plan-only with an HA automation as the actuator
+remains a supported fallback — see "EV actuation in OptiVolt" below.
+
+> **Note — this expands OptiVolt's role.** Today OptiVolt's only actuator is
+> Victron MQTT; everything HA-related is read-only. Adding charger control means
+> OptiVolt issues HA **service calls** (a new write path) and runs its own fast
+> control loop. The design below makes that safe: idempotent, fail-safe, single
+> owner.
 
 ---
 
@@ -140,6 +148,12 @@ accordingly:
   `api/routes/ev.ts`): low-price, low-SoC, keep-on. These read **live** price +
   EV SoC at request time and override the planned decision for `/ev/current`
   (and annotate `/ev/schedule`). They do **not** require re-solving the LP.
+- **Actuation layer** (new `api/services/ev-actuator-service.ts`): a fast control
+  tick that takes the effective decision from the override layer and **drives the
+  charger** via HA service calls (`switch.turn_on`/`switch.turn_off`, plus
+  optional `number.set_value` for current), idempotently and fail-safe. This is
+  the piece that makes OptiVolt independent of the integration. See "EV actuation
+  in OptiVolt".
 
 This keeps the expensive solve day-ahead while the reactive behaviors stay live
 and cheap, exactly matching the integration's feel.
@@ -167,6 +181,13 @@ evLowSocChargingLevel_percent?: number;
 evContinuous?: boolean;
 evKeepOn?: boolean;
 evSource?: 'native' | 'haSchedule';            // default 'native'; 'haSchedule' = legacy reader
+// Actuation (OptiVolt drives the charger itself — see "EV actuation in OptiVolt")
+evActuationEnabled?: boolean;                  // default false; when true OptiVolt controls the charger
+evChargerSwitchEntity?: string;                // switch.* that starts/stops charging
+evChargerCurrentEntity?: string;               // number.* charge current in A (optional)
+evControlIntervalSeconds?: number;             // actuator tick cadence, default 60
+evFailSafeMode?: 'hold' | 'stop';              // on error/restart: 'hold' = no write (default), 'stop' = turn off
+evActuationPaused?: boolean;                    // user kill-switch to suspend OptiVolt charger control
 ```
 
 Add matching defaults to `api/defaults/default-settings.json` and validation in
@@ -340,11 +361,14 @@ Each new control needs: the element id, registration in
 | 5 | Opportunistic value bands (incl. type 2) | EV tops up beyond target only when cheap |
 | 6 | EV tab mode badge + target-met indicator + schedule annotation | UI surfaces active/forecast mode |
 | 7 (optional) | Continuous-charging MILP contiguity penalty | Fewer charge on/off cycles when enabled |
-| 8 | HA actuation glue documented + sample automation (Appendix) | HA drives charger from OptiVolt decision |
+| 8 | HA service-call write path (`callHaService`) + charger control settings | OptiVolt can switch the charger + set current via HA |
+| 9 | EV actuator service (fast tick, idempotent, fail-safe) + cutover | OptiVolt owns EV charging end-to-end; integration uninstalled |
 
-Phases 1–6 reach functional parity for the requested low-price / low-SoC / price
-limit / min SoC / opportunistic settings. 7 is a refinement; 8 is the HA-side
-companion.
+Phases 1–6 reach **decision parity** for low-price / low-SoC / price limit /
+min SoC / opportunistic. 7 refines charge-cycling. **8–9 give OptiVolt charger
+actuation so the EV Smart Charging integration can be removed entirely** — this
+is the difference between "OptiVolt has all the planning logic" and "OptiVolt is
+independent of the integration".
 
 ---
 
@@ -361,7 +385,12 @@ Per `AGENTS.md`: `npm run typecheck`, `npm run lint`, `npm run test:run`.
   (low-SoC > low-price > min-SoC floor > planned); plug-status gating; mode +
   power returned; tolerant of missing HA (falls back to planned).
 - **Route tests**: `/ev/current` reflects overrides; `/ev/schedule` annotations;
-  `/ev/status` shape.
+  `/ev/status` shape; `/ev/actuation` reports last command.
+- **`ev-actuator-service`** (`tests/api/`): idempotent writes (no duplicate
+  service call when desired state is unchanged); fail-safe (no charger write on
+  HA error / missing plan / restart); plug-gating; `evFailSafeMode: 'stop'`
+  issues a single `turn_off` on sustained error; `evActuationPaused` suspends
+  control; mock `callHaService`.
 - **Browser** (`tests/app/`): new settings inputs hydrate and snapshot; mode
   badge renders per `/ev/current`; `haSchedule` source hides native controls.
 
@@ -381,28 +410,93 @@ If a release is cut, bump the 3 version files + `CHANGELOG.md` per `CLAUDE.md`.
 - The live decision (`/ev/current`) flips to **low-SoC** then **low-price**
   overrides by priority, reacting to live SoC and price without re-solving; the
   EV tab shows the active mode.
-- OptiVolt remains plan-only; an HA automation actuates the charger from the
-  `/ev/*` endpoints (Appendix). The legacy `haSchedule` reader still works when
-  selected.
+- With `evActuationEnabled`, OptiVolt **drives the charger directly** via HA
+  service calls on a fast control tick — idempotently and fail-safe (no charger
+  write on error or restart) — so the **EV Smart Charging integration can be
+  uninstalled**. Plan-only + an HA actuation automation remains a supported
+  fallback, and the legacy `haSchedule` reader still works when selected.
 - `npm run typecheck`, `npm run lint`, and `npm run test:run` pass.
 
 ---
 
-## Appendix: Home Assistant actuation glue
+## EV actuation in OptiVolt
 
-OptiVolt plans; HA drives the charger. This glue lives in the
-`vervoto1/homeassistant` repo, documented here for completeness.
+This is the piece that makes OptiVolt **independent** of the EV Smart Charging
+integration: OptiVolt drives the physical charger itself via Home Assistant
+service calls, so the integration can be uninstalled. (If you prefer to keep
+OptiVolt plan-only, skip this and use the HA-automation fallback at the end.)
 
-- Expose OptiVolt's decision to HA as a REST sensor polling
-  `http://optivolt:3000/ev/status` (or `/ev/current`), surfacing `mode`,
-  `is_charging`, and `ev_charge_A`.
-- An HA automation reacts to that sensor: start/stop the Tesla Wall Connector and
-  set charging current to `ev_charge_A` when `is_charging` is true; stop
-  otherwise. The current EV Smart Charging integration can be retired, or kept in
-  a passive/manual mode purely as the charger-control shim while OptiVolt owns
-  planning.
-- Keep the JK BMS safety automation (Victron max charge current) unchanged; it is
-  independent of EV planning.
-- Because the charger sits behind the Victron inverter, EV draw already affects
-  grid import/export in the LP — no extra coupling is needed beyond the existing
-  EV flow variables.
+### HA service-call write path (`api/services/ha-client.ts`)
+
+OptiVolt's `ha-client.ts` is read-only today. Add a generic writer:
+
+```ts
+callHaService({ haUrl, haToken, domain, service, target, data }):
+  Promise<void>;   // POST {baseUrl}/api/services/{domain}/{service}
+```
+
+Reuse `resolveHaHttpConfig` for credentials: in add-on mode it posts through the
+supervisor proxy (`http://supervisor/core` + `SUPERVISOR_TOKEN`); the add-on
+manifest `optivolt/config.yaml` must declare `homeassistant_api: true` so the
+supervisor allows service calls. Keep the function generic — the EV actuator is
+just its first caller.
+
+### Actuator service (`api/services/ev-actuator-service.ts`)
+
+A lightweight control loop, **separate** from the 15-min planner, registered at
+server start the same way `api/services/auto-calculate.ts` is wired:
+
+1. Every `evControlIntervalSeconds` (default 60), compute the effective decision
+   with `computeEvDecision(settings, getLastPlan())` from the override layer.
+2. Gate first: if `!evActuationEnabled` or `evActuationPaused`, do nothing. If
+   the EV is not plug-connected, ensure the charger is off (subject to fail-safe)
+   and return.
+3. Drive the charger **idempotently** — only issue a service call when the desired
+   state differs from the last command OptiVolt sent (track last command in
+   memory):
+   - on/off via `callHaService('switch', is_charging ? 'turn_on' : 'turn_off', { entity_id: evChargerSwitchEntity })`
+   - charge current, if `evChargerCurrentEntity` is set, via
+     `callHaService('number', 'set_value', { entity_id: evChargerCurrentEntity }, { value: ev_charge_A })`
+4. Record the last actuation (mode, command, value, timestamp, ok/error) in
+   memory for `GET /ev/actuation` and the EV-tab badge.
+
+Add a small `GET /ev/actuation` route returning that last-actuation record for
+observability.
+
+### Fail-safe and ownership rules
+
+- **Single owner.** When `evActuationEnabled`, OptiVolt is the **only** writer to
+  the charger entities. The EV Smart Charging integration must be
+  disabled/removed so the two never fight (the cutover steps enforce this).
+- **Fail-safe = no write on uncertainty.** On any error (HA unreachable, missing
+  live SoC/price, no current plan) or right after an OptiVolt restart, the
+  actuator makes **no** charger write — the charger holds its last physical
+  state. Never leave the charger forced-on as a side effect of a failure.
+  `evFailSafeMode: 'stop'` is an opt-in stricter mode that issues a single
+  `turn_off` on sustained error.
+- **Respect manual control.** A user toggling the charger by hand should not be
+  instantly reverted; `evActuationPaused` suspends OptiVolt control, and the
+  idempotent design avoids spamming writes.
+- **Clean startup.** On boot, read the charger's current state before the first
+  command so the first tick is idempotent and does not blip the charger.
+
+### Cutover — retire the integration
+
+1. Configure `evChargerSwitchEntity` (and optionally `evChargerCurrentEntity`),
+   then enable `evActuationEnabled`.
+2. Disable the EV Smart Charging integration's charger control (or uninstall it)
+   so there is a single owner.
+3. Verify a full cycle: plug in below target → OptiVolt charges in the planned
+   cheap slots; force a low-SoC or low-price condition → OptiVolt charges
+   immediately; reach target → OptiVolt stops.
+4. Leave the JK BMS safety automation (Victron max charge current) unchanged — it
+   is independent of EV charging. The charger sits behind the Victron inverter,
+   so EV draw already affects grid import/export in the LP; no extra coupling is
+   needed beyond the existing EV flow variables.
+
+### Fallback — keep OptiVolt plan-only (optional)
+
+Leave `evActuationEnabled` off and drive the charger from an HA automation that
+polls `GET /ev/current` / `GET /ev/status` (`mode`, `is_charging`,
+`ev_charge_A`) and calls `switch.turn_on` / `switch.turn_off` (+ current).
+Same decision source; actuation just lives in HA instead of OptiVolt.

--- a/plans/ev-native-charging-plan.md
+++ b/plans/ev-native-charging-plan.md
@@ -79,6 +79,78 @@ compatibility (see "Source selection" below).
 
 ---
 
+## Foundations (Phase 0 — do these BEFORE any new feature/MILP/actuation work)
+
+A cross-model review (eng review + two independent outside voices) converged on
+one point: **fix the physical model and ownership boundaries first.** These are
+pre-existing correctness issues that every later phase inherits and amplifies.
+None of phases 1-9 are safe to build until Phase 0 lands.
+
+### 0a. Three-phase charge power (SHIPPED bug)
+
+The amps↔watts conversion is hardcoded **single-phase**:
+`config-builder.ts:119-120` uses `evMaxChargeCurrent_A * 230`, and
+`parse-solution.ts:4` is `const EV_CHARGE_VOLTAGE_V = 230; // single-phase`.
+The target charger is an **11 kW three-phase** Tesla Wall Connector, so at 16 A
+the model plans/actuates ~3.7 kW instead of ~11 kW — and the actuator would
+command amps off that wrong wattage.
+
+- Add a setting `evChargePhases?: 1 | 3` (default `3` for this hardware) — or
+  equivalently `evChargeVoltage_V` — and define one shared constant
+  `EV_W_PER_A = phases * 230`.
+- Replace the hardcoded `* 230` / `/ 230` at **both** sites (`config-builder.ts`
+  and `parse-solution.ts`) with that constant so the LP build and the solution
+  parse agree. Add it to defaults + schema (1 or 3) and surface it in the UI.
+- Test: 16 A on a 3-phase config ⇒ ~11 kW max power in the LP and ~16 A back
+  out of parse; 1-phase config ⇒ ~3.7 kW (regression guard against re-hardcoding).
+
+### 0b. One authoritative EV ownership (legacy vs native double-count)
+
+`id="ev-enabled"` exists **twice** (`index.html:1508` and `:1934`);
+`getElementById` returns the first, and `state.js` writes **both**
+`evConfig.enabled` (legacy) and flat `evEnabled` (native) from that single
+element (`state.js:47`,`:123`,`:200`,`:209`). Meanwhile `planner-service.ts:210`
+injects the legacy HA `evLoad` whenever `evConfig.enabled`. Net effect: enabling
+native EV also enables the legacy reader, so native LP charge **and** injected
+`evLoad_W` both land → **double-counted EV load**.
+
+- Collapse the EV configuration to **one authoritative mode**. `evSource`
+  (`'native' | 'haSchedule'`) becomes that switch — but it must replace the
+  shared `ev-enabled` checkbox, not sit alongside it. Remove the duplicate id;
+  give the legacy and native blocks distinct ids; derive `evConfig.enabled`
+  strictly from `evSource === 'haSchedule'` and `evEnabled` from
+  `evSource === 'native'`, never from the same element.
+- Gate `planner-service.ts:210` on `evSource === 'haSchedule'` so the legacy
+  `evLoad` injection cannot fire in native mode.
+- This also resolves the "evSource is a 4th concept" concern: there is exactly
+  one EV mode selector; `dataSources.evLoad`, legacy `evConfig`, and flat native
+  settings all hang off it.
+- Test: native mode does not inject `evLoad_W`; legacy mode does; the two cannot
+  both be active.
+
+### 0c. Runtime overrides must reconcile with the Victron DESS schedule
+
+`dess-mapper.ts:90` builds the schedule written to Victron from the **planned**
+`ev_charge` (`expectedLoad = row.load + row.ev_charge`). A low-SoC/low-price
+override that charges full-power **off-plan** is invisible to the DESS schedule
+already pushed to Victron, so Victron can discharge the home battery into the EV
+or violate planned grid limits until the next solve+write.
+
+Pick one (document the choice):
+- **(preferred) Override triggers a fast re-plan+re-write.** When the override
+  layer changes the effective EV decision, run a (cheap) re-solve with the
+  override's EV draw pinned and re-write the Victron DESS schedule, so the
+  battery/grid plan stays consistent. Reuses the existing planner+mqtt write path.
+- **or bound the override to the planned envelope** — overrides may only *shift
+  within* the already-scheduled EV power/grid budget, never exceed it (weaker;
+  defeats "charge now regardless").
+
+Until 0c is decided, the actuation phases (8-9) must not ship — an off-plan
+charger command without a matching Victron schedule is the exact "two systems
+disagree about the battery" failure.
+
+---
+
 ## The EV Smart Charging features to port
 
 Mapped from the integration's entities (`const.py`, `number.py`, `switch.py`,
@@ -165,8 +237,11 @@ and cheap, exactly matching the integration's feel.
 ### `api/types.ts` (extend the EV block in `Settings`)
 
 ```ts
+// Phase 0: physical model (fixes the shipped single-phase assumption)
+evChargePhases?: 1 | 3;                         // default 3 here; sets EV_W_PER_A = phases*230
+evMaxPlanAgeSeconds?: number;                   // actuator: ignore plans older than this (fail-safe)
 evStartTime?: string;                          // earliest charge time (ISO local), optional
-evChargingSpeed_pct_per_h?: number;            // informational/derived (see notes)
+evChargingSpeed_pct_per_h?: number;            // informational/derived, NOT persisted — compute in UI
 evApplyPriceLimit?: boolean;
 evMaxPrice_cents_per_kWh?: number;
 evMinSoc_percent?: number;
@@ -256,13 +331,23 @@ SoC, opportunistic levels, and continuity through. Effective opportunistic cap =
    `ev_soc_{depSlot-1} ≥ evTargetWh`) with a soft constraint: add a non-negative
    `ev_target_shortfall` and the constraint
    `ev_soc_{depSlot-1} + ev_target_shortfall ≥ evTargetWh`, plus
-   `BIG_PENALTY × ev_target_shortfall` in the objective. `BIG_PENALTY` must sit
-   **above** the largest per-Wh import cost in the horizon but **below** the
-   `softMinSocPenalty`/`TIEBREAK` scales so it doesn't distort battery economics —
-   reuse the existing magnitude discipline (the TIEBREAK ladder is `5e-7…4e-6`;
-   the shortfall penalty is a *large* coefficient, e.g. `100` c€/Wh, far above any
-   realistic price). Surface `ev_target_shortfall` in the solution so
-   `parse-solution` can derive `ev_target_met`.
+   `BIG_PENALTY × ev_target_shortfall` in the objective.
+
+   **Dimensions (get this right — the objective mixes scales).** Objective
+   coefficients are in **c€ per Wh of the variable**: import terms are
+   `price_cents × priceCoeff` (`build-lp.ts:128`), the soft battery-min-SoC
+   penalty is `0.05` c€/Wh (`build-lp.ts:125`), and the TIEBREAKs are `~1e-6`
+   (`build-lp.ts:112`). `ev_target_shortfall` is a Wh quantity, so `BIG_PENALTY`
+   is a c€/Wh coefficient that must be **strictly greater than the largest
+   achievable per-Wh saving from *not* charging** (i.e. above
+   `max(importPrice) × priceCoeff` over the horizon, with margin) so the solver
+   always prefers hitting the target when it physically/price-mask can. It is NOT
+   "below TIEBREAK/softMinSoc" — it is the largest coefficient in the objective.
+   Compute it from the actual price array (e.g.
+   `BIG_PENALTY = max(importCoeff_cents) × 10`) rather than a magic constant, and
+   assert the ordering `BIG_PENALTY ≫ batteryCost ≫ softMinSoc ≫ TIEBREAK` in a
+   test. Surface `ev_target_shortfall` in the solution so `parse-solution` can
+   derive `ev_target_met`.
 
    3a. **Remove/recompute the cardinality lower bound.** `c_ev_min_on`
    (`build-lp.ts:462`, `Σ ev_on_t ≥ kMin`) was derived from the *hard* deficit and
@@ -274,20 +359,29 @@ SoC, opportunistic levels, and continuity through. Effective opportunistic cap =
    Prefer (b) only if you still want the relaxation-tightening; (a) is simpler and
    safe. This is the single highest-risk LP interaction — cover it with the
    regression test in Testing.
-4. **Minimum-SoC floor (hard, MILP-gated, mask-exempt).** A *static* mask cannot
-   express "exempt the floor slots" because the floor slots aren't known at build
-   time. Use a MILP indicator instead:
-   - Add `ev_soc_t ≥ evMinFloorWh` for all `t` at/after the first slot the floor
-     is physically reachable from `evInitialWh` at max power (a hard floor, like
-     today's soc bounds — independent of price).
-   - Introduce a binary `ev_floor_active_t` and a separate flow term
-     `ev_floor_charge_t` (AC into the charger) that is **excluded from the price
-     mask**. Bound `ev_floor_charge_t = 0` whenever the floor is already satisfied
-     (`ev_soc_{t-1} ≥ evMinFloorWh` ⇒ via the indicator), and route it into
-     `c_ev_soc_t` exactly like `grid_to_ev` (AC, `evChargeWhPerW` factor).
-   - The floor charge competes with nothing on price (it's a safety obligation),
-     so it carries only the normal import cost in the objective, no mask, no
-     opportunistic reward.
+4. **Minimum-SoC floor (soft-with-huge-penalty, mask-exempt, fully sourced).**
+   Two traps to avoid: (i) a *static* mask cannot "exempt the floor slots"
+   because the floor slots aren't known at build time; (ii) a **hard** floor can
+   make the whole LP infeasible — reachability isn't just charger power and slot
+   count, it's also bounded by house-load balance (`c_load`, `build-lp.ts:293`)
+   and the grid-import cap (`build-lp.ts:336`), so "first physically reachable
+   slot" computed from `evMaxPow_W` alone (as `config-builder.ts:128` does today)
+   can be wrong. Therefore make the floor **soft with a penalty above
+   `BIG_PENALTY`** (floor outranks target), never a hard constraint:
+   - Add `ev_soc_t + ev_floor_shortfall_t ≥ evMinFloorWh` for `t` from the
+     earliest *estimated* reachable slot, with `FLOOR_PENALTY × ev_floor_shortfall_t`
+     in the objective and `FLOOR_PENALTY > BIG_PENALTY` (priority: floor > target).
+     Soft ⇒ the model is always feasible; the penalty ⇒ the floor is met whenever
+     physically possible.
+   - Mask-exemption via a dedicated, **fully sourced** flow `ev_floor_charge_t`
+     (AC into the charger) that is excluded from the price mask. It must NOT be
+     free energy: split it into `g2ev_floor_t + η_inv·pv2ev_floor_t +
+     η_inv·b2ev_floor_t` (same source decomposition as `ev_charge`), feed those
+     into `c_ev_soc_t` with the correct `evChargeWhPerW`/`evChargeWhPerW_dc`
+     factors, **and add `g2ev_floor_t` into the grid-import cap** (`build-lp.ts:334`)
+     and the PV/battery source balances, exactly like `grid_to_ev`/`pv_to_ev`/
+     `battery_to_ev`. Cap total `ev_floor_charge_t ≤ evMaxPow_W` and bound it to 0
+     once the floor is satisfied.
 
    ```
    PRICE-MASK vs MIN-SOC-FLOOR (decision)
@@ -297,8 +391,9 @@ SoC, opportunistic levels, and continuity through. Effective opportunistic cap =
                     │
                     └─ but ev_soc_{t-1} < evMinFloorWh ?
                           │ no ──► stays masked (0)
-                          └ yes ─► ev_floor_charge_t > 0 allowed (mask-exempt,
-                                    pays import cost, bounded by evMaxPow_W)
+                          └ yes ─► ev_floor_charge_t > 0 allowed (mask-exempt),
+                                    sourced from grid/pv/battery, counted in the
+                                    grid-import cap, bounded by evMaxPow_W
    ```
 5. **Opportunistic value band (bounded reward).** For SoC above target up to the
    opportunistic cap, add a small **negative cost** on stored EV energy in that
@@ -426,9 +521,10 @@ Each new control needs: the element id, registration in
 
 | Phase | Scope | Output |
 |-------|-------|--------|
+| **0** | **Foundations (see section above): 3-phase units, one authoritative EV ownership, override↔DESS reconciliation** | **Physical model + ownership correct; no double-count; overrides keep Victron consistent** |
 | 1 | Settings: new EV fields + defaults + schema; UI inputs wired (no behavior yet) | Settings round-trip; controls visible |
-| 2 | LP masks: earliest-start + price limit; soft target SoC | Plan respects window + price ceiling; stays feasible |
-| 3 | Minimum-SoC floor | EV guaranteed to reach min SoC ASAP, mask-exempt |
+| 2 | LP masks: earliest-start + price limit; soft target SoC (+ cardinality-bound fix #3a) | Plan respects window + price ceiling; stays feasible |
+| 3 | Minimum-SoC floor (soft, sourced, mask-exempt) | EV reaches min SoC ASAP when feasible; never infeasible |
 | 4 | Runtime overrides: low-price + low-SoC + keep-on in `ev-decision-service` + `/ev/current` | Live decision flips to override modes correctly |
 | 5 | Opportunistic value bands (incl. type 2) | EV tops up beyond target only when cheap |
 | 6 | EV tab mode badge + target-met indicator + schedule annotation | UI surfaces active/forecast mode |
@@ -436,11 +532,14 @@ Each new control needs: the element id, registration in
 | 8 | HA service-call write path (`callHaService`) + charger control settings | OptiVolt can switch the charger + set current via HA |
 | 9 | EV actuator service (fast tick, idempotent, fail-safe) + cutover | OptiVolt owns EV charging end-to-end; integration uninstalled |
 
-Phases 1–6 reach **decision parity** for low-price / low-SoC / price limit /
-min SoC / opportunistic. 7 refines charge-cycling. **8–9 give OptiVolt charger
-actuation so the EV Smart Charging integration can be removed entirely** — this
-is the difference between "OptiVolt has all the planning logic" and "OptiVolt is
-independent of the integration".
+**Phase 0 is a hard prerequisite for all of 1-9** (cross-model consensus): the
+three-phase fix, the legacy/native ownership collapse, and the override↔DESS
+reconciliation are correctness foundations, not enhancements. Phases 1–6 then
+reach **decision parity** for low-price / low-SoC / price limit / min SoC /
+opportunistic. 7 refines charge-cycling. **8–9 give OptiVolt charger actuation so
+the EV Smart Charging integration can be removed entirely** — and must not ship
+until 0c (override↔DESS) is decided, or an off-plan charger command can fight the
+Victron schedule.
 
 ---
 
@@ -464,6 +563,23 @@ Per `AGENTS.md`: `npm run typecheck`, `npm run lint`, `npm run test:run`.
   - **No false "target met".** With the requested target above what's reachable,
     assert `ev_target_met === false` and `ev_target_shortfall > 0` (proves the
     `achievableTargetWh` clamp no longer masks the shortfall).
+  - **Phase 0 — three-phase units.** `evChargePhases: 3` + 16 A ⇒ ~11 kW max EV
+    power in the LP and ~16 A back out of `parse-solution`; `evChargePhases: 1`
+    ⇒ ~3.7 kW. Regression guard against re-hardcoding 230.
+  - **Min-SoC floor never infeasible.** Construct a case where the floor is NOT
+    reachable given house load + grid-import cap; assert the LP is **feasible**
+    with `ev_floor_shortfall > 0` (soft floor), not an infeasible solve.
+  - **Floor charge is sourced + capped.** Assert `ev_floor_charge_t` increments
+    EV SoC only via grid/pv/battery sub-flows and that `g2ev_floor_t` is counted
+    in the grid-import cap (no free energy).
+  - **Penalty ordering.** Assert `FLOOR_PENALTY > BIG_PENALTY ≫ batteryCost ≫
+    softMinSoc ≫ TIEBREAK` for the generated coefficients.
+- **Phase 0 — ownership (`tests/api/`)**: native mode (`evSource:'native'`) does
+  NOT inject legacy `evLoad_W` via `planner-service`; `haSchedule` mode does;
+  the two cannot both be active (no shared `ev-enabled` element).
+- **Phase 0 — override↔DESS (`tests/api/`)**: an override that deviates from the
+  planned EV draw triggers a re-plan + Victron re-write (or is bounded to the
+  planned envelope), so the written DESS schedule matches actual charger draw.
 - **`ev-decision-service`** (`tests/api/`): priority ordering
   (low-SoC > low-price > min-SoC floor > planned); plug-status gating; mode +
   power returned; tolerant of missing HA (falls back to planned).
@@ -542,14 +658,27 @@ server start the same way `api/services/auto-calculate.ts` is wired:
 1. Every `evControlIntervalSeconds` (default 60), compute the effective decision
    with `computeEvDecision(settings, getLastPlan())` from the override layer.
 
-   > **Dependency — actuation needs a current plan, which needs auto-calculate.**
-   > `getLastPlan()` is populated only by `auto-calculate.ts`, which is opt-in
-   > (`if (!config?.enabled) return;`). If a user enables `evActuationEnabled`
-   > but not `autoCalculate`, `getLastPlan()` is `null` forever and (per
-   > fail-safe) the charger is never driven — a **silent** dead feature. Surface
-   > this: on actuator start, if auto-calculate is disabled, log a warning and
-   > report it in `GET /ev/actuation` (`status: 'no_plan_source'`). Optionally
-   > trigger a solve from the actuator. Add a startup-validation test.
+   > **Dependency + freshness — don't trust `getLastPlan()` blindly.**
+   > `getLastPlan()` is in-memory and replaced **only after a solve completes**
+   > (`planner-service.ts:307`), by either `auto-calculate.ts` (opt-in:
+   > `if (!config?.enabled) return;`) **or** a manual `POST /calculate`
+   > (`calculate.ts:21`). So:
+   > - **No plan source:** if neither auto-calculate is enabled nor a plan has
+   >   ever been computed, `getLastPlan()` is `null` → no charger write (silent
+   >   dead feature). On actuator start, warn and report
+   >   `status: 'no_plan_source'` in `GET /ev/actuation`; optionally trigger a
+   >   solve. Startup-validation test required.
+   > - **Staleness:** a plan can be up to one auto-calc interval old (or older if
+   >   auto-calc is off and nobody hit `/calculate`). The actuator must read a
+   >   **plan-freshness timestamp** and treat a plan older than a configurable
+   >   `evMaxPlanAgeSeconds` as "uncertain → no write" (fail-safe), not act on
+   >   stale slots.
+   > - **Observed-state reconciliation, not just `lastCommand`:** each tick,
+   >   reconcile *intended* state against the charger's *observed* state (the
+   >   contention check in step 4 is part of this), since `lastCommand` memory is
+   >   lost on restart and can diverge from physical reality.
+   > - Snapshot the `getLastPlan()` reference once per tick (it can be swapped
+   >   mid-tick with no locking).
 2. Gate first: if `!evActuationEnabled` or `evActuationPaused`, do nothing.
    Plug-status gating with **staleness awareness**: read `evPlugSensor`; if the
    value is `unavailable`/`unknown` (a transient HA hiccup), treat it as

--- a/plans/ev-native-charging-plan.md
+++ b/plans/ev-native-charging-plan.md
@@ -1,0 +1,408 @@
+# EV Native Charge Planning — Feature Parity Plan
+
+## Status
+
+Planned. Not started. Builds on the completed work in
+`plans/ev-charging-plan.md` (native LP-integrated planned charging already
+ships). This document is a self-contained build brief.
+
+## Goal
+
+Make **OptiVolt the EV charge planner** with the full feature set of the Home
+Assistant **EV Smart Charging** integration
+(`jonasbkarlsson/ev_smart_charging`), so the external integration's *planning*
+logic can be retired. The EV screen gains the settings that integration has and
+OptiVolt currently lacks — notably **low-price charging** and **low-SoC
+charging** — plus price limit, minimum SoC, opportunistic charging, continuous
+charging, keep-on, and an earliest-start window.
+
+OptiVolt continues to **plan only**; Home Assistant continues to **actuate** the
+physical charger (Tesla Wall Connector, 11 kW). OptiVolt exposes the plan and
+the live decision over `/ev/*`; an HA automation drives the charger from it (see
+the Appendix). This preserves OptiVolt's design rule: "HA controls the physical
+charger, OptiVolt only plans."
+
+---
+
+## What exists today (read first)
+
+### Native LP planned charging (already merged)
+
+`Settings` in `api/types.ts` already has the EV block:
+
+```ts
+evEnabled: boolean;
+evMinChargeCurrent_A: number;
+evMaxChargeCurrent_A: number;
+evBatteryCapacity_kWh: number;
+evSocSensor: string;
+evPlugSensor: string;
+evDepartureTime: string;        // "ready by" (ISO local datetime)
+evTargetSoc_percent: number;
+evChargeEfficiency_percent: number;
+```
+
+- `lib/build-lp.ts` adds EV flow variables following the `{source}_to_{sink}_{t}`
+  pattern: `grid_to_ev_t`, `pv_to_ev_t`, `battery_to_ev_t`. Total per slot
+  `ev_charge_t = g2ev + pv2ev + b2ev`, bounded by min/max power
+  (`current_A × 230 V`) with a binary on/off, and EV SoC is tracked with a hard
+  "reach target by departure slot" constraint.
+- `lib/parse-solution.ts` extracts `ev_charge`, `ev_charge_A`, `ev_charge_mode`,
+  `g2ev`, `pv2ev`, `b2ev`, `ev_soc_percent` per row.
+- `api/services/config-builder.ts` builds the EV solver config from settings +
+  data.
+- `api/routes/ev.ts` exposes `GET /ev/schedule` (full per-slot plan + summary)
+  and `GET /ev/current` (current slot's decision, `is_charging`).
+- UI: the **EV tab** (`panel-ev` in `app/index.html`, logic in
+  `app/src/ev-tab.js`, settings wiring in `app/src/ev-settings.js`) shows ready-by
+  time, target SoC, live SoC/plug from HA, a charge split (grid/battery/PV), cost
+  and effective rate, and per-slot mode rows. The Settings tab also has an "EV
+  Charging" card.
+
+### Legacy external-schedule reader (to be superseded)
+
+`api/services/ha-ev-service.ts` + `EvConfig` in `api/types.ts`
+(`scheduleSensor`, `scheduleAttribute`, `connectedSwitch`, `alwaysApplySchedule`,
+`chargerPower_W`, `disableDischargeWhileCharging`) read the **external** EV
+Smart Charging integration's `charging_schedule` attribute and inject it as
+`evLoad`. Once native planning has parity, this path becomes optional. **Do not
+delete it** in this work — keep it as a selectable EV source for backward
+compatibility (see "Source selection" below).
+
+---
+
+## The EV Smart Charging features to port
+
+Mapped from the integration's entities (`const.py`, `number.py`, `switch.py`,
+`coordinator.py`, `helpers/coordinator.py`). Each row notes how OptiVolt should
+realize it: as a **day-ahead LP** element (planned, cost-optimal) or as a
+**runtime override** (reacts to live price/SoC, applied after the solve).
+
+| EV Smart Charging feature | Entity | OptiVolt realization |
+|---|---|---|
+| Smart charging activated | `switch.smart_charging_activated` | `evEnabled` (exists) |
+| Ready-by time | `select.charge_completion_time` | `evDepartureTime` (exists) |
+| Earliest-start time | `select.charge_start_time` | NEW `evStartTime` → LP mask |
+| Target SoC | (target SoC sensor) | `evTargetSoc_percent` (exists) |
+| Charging speed (%/h) | `number.charging_speed` | NEW `evChargingSpeed_pct_per_h` (derive/display; see notes) |
+| Price limit on/off + value | `switch.apply_price_limit` + `number.electricity_price_limit` | NEW `evApplyPriceLimit` + `evMaxPrice_cents_per_kWh` → LP mask + soft target |
+| Minimum SoC | `number.minimum_ev_soc` | NEW `evMinSoc_percent` → LP floor + runtime override |
+| Opportunistic charging + level | `switch.opportunistic_charging` + `number.opportunistic_level` | NEW `evOpportunisticEnabled` + `evOpportunisticLevel_percent` → LP value band |
+| Opportunistic type 2 + level | `switch.opportunistic_type2_charging` + `number.opportunistic_type2_level` | NEW `evOpportunisticType2Enabled` + `evOpportunisticType2Level_percent` → LP value band |
+| Low-price charging + level | `switch.low_price_charging` + `number.low_price_charging_level` | NEW `evLowPriceChargingEnabled` + `evLowPriceChargingLevel_cents_per_kWh` → **runtime override** |
+| Low-SoC charging + level | `switch.low_soc_charging` + `number.low_soc_charging_level` | NEW `evLowSocChargingEnabled` + `evLowSocChargingLevel_percent` → **runtime override** |
+| Continuous charging preferred | `switch.continuous_charging_preferred` | NEW `evContinuous` → MILP contiguity penalty |
+| Keep charger on | `switch.keep_charger_on` | NEW `evKeepOn` → **runtime override** |
+
+### Semantics (from `coordinator.py`)
+
+- **Low-price charging** (override): when the switch is on **and** the *current*
+  buy price is at or below `low_price_charging_level`, charge **now** at full
+  power regardless of the plan. Status becomes `low_price_charging`.
+- **Low-SoC charging** (override): when the switch is on **and** the *current* EV
+  SoC is **below** `low_soc_charging_level`, charge **now** regardless of price
+  or plan. Status becomes `low_soc_charging`. This has **priority over**
+  low-price.
+- **Minimum SoC**: bring the EV up to `min_soc` as soon as possible (a hard
+  safety floor), independent of price.
+- **Price limit**: never charge in slots whose price exceeds the limit. If the
+  cheap-enough slots are insufficient to hit the target, the target is **not**
+  forced — the car simply ends below target. (This makes the day-ahead target a
+  *soft* objective under a price-limit *hard* mask.)
+- **Opportunistic**: when charging anyway / when prices are favourable, top the
+  EV up beyond the target toward the opportunistic level. Type 2 is a second,
+  higher band (level can exceed 100% in the integration's UI; clamp to a sane
+  cap such as 100% for SoC banding here).
+- **Continuous**: prefer a single contiguous charging block over the absolute
+  cheapest scattered slots, to reduce charger on/off cycling.
+- **Keep-on**: once charging has begun, keep the charger energized until the
+  ready time / target rather than pausing between cheap slots.
+
+### Priority order for the live decision
+
+`low_soc` > `low_price` > `min_soc floor` > `planned (LP)` > idle. `keep_on`
+holds the charger on once started within the active charging window.
+
+---
+
+## Design: LP layer vs runtime-override layer
+
+OptiVolt's strength is a **day-ahead, system-wide cost-optimal** LP. EV Smart
+Charging mixes day-ahead planning with **real-time reactions**. Split the port
+accordingly:
+
+- **LP / planning layer** (`lib/build-lp.ts`, `lib/types.ts`,
+  `api/services/config-builder.ts`): earliest-start window, price-limit mask,
+  **soft** target SoC, minimum-SoC floor, opportunistic value bands, continuous
+  contiguity penalty. These shape the persisted plan and the Victron DESS
+  schedule.
+- **Runtime-override layer** (new `api/services/ev-decision-service.ts`, used by
+  `api/routes/ev.ts`): low-price, low-SoC, keep-on. These read **live** price +
+  EV SoC at request time and override the planned decision for `/ev/current`
+  (and annotate `/ev/schedule`). They do **not** require re-solving the LP.
+
+This keeps the expensive solve day-ahead while the reactive behaviors stay live
+and cheap, exactly matching the integration's feel.
+
+---
+
+## Settings additions
+
+### `api/types.ts` (extend the EV block in `Settings`)
+
+```ts
+evStartTime?: string;                          // earliest charge time (ISO local), optional
+evChargingSpeed_pct_per_h?: number;            // informational/derived (see notes)
+evApplyPriceLimit?: boolean;
+evMaxPrice_cents_per_kWh?: number;
+evMinSoc_percent?: number;
+evOpportunisticEnabled?: boolean;
+evOpportunisticLevel_percent?: number;
+evOpportunisticType2Enabled?: boolean;
+evOpportunisticType2Level_percent?: number;
+evLowPriceChargingEnabled?: boolean;
+evLowPriceChargingLevel_cents_per_kWh?: number;
+evLowSocChargingEnabled?: boolean;
+evLowSocChargingLevel_percent?: number;
+evContinuous?: boolean;
+evKeepOn?: boolean;
+evSource?: 'native' | 'haSchedule';            // default 'native'; 'haSchedule' = legacy reader
+```
+
+Add matching defaults to `api/defaults/default-settings.json` and validation in
+`api/services/settings-schema.ts` (booleans, numeric ranges: percentages
+0..100, prices may be negative, times are ISO strings or empty).
+
+Notes on **charging speed (%/h)**: EV Smart Charging needs it because it does not
+know charger power; OptiVolt already knows `evBatteryCapacity_kWh` and min/max
+power, so it derives charge rate directly. Keep `evChargingSpeed_pct_per_h` as an
+optional *display/derived* value (and, if set, an alternative way to express max
+power = `pct_per_h/100 × capacity_kWh × 1000`). The min/max current settings
+remain the source of truth for the LP; surface the implied %/h read-only in the
+UI so users migrating from EV Smart Charging recognize it.
+
+---
+
+## LP / planning changes
+
+### `lib/types.ts` — extend `SolverConfig` EV fields
+
+Add: `evStartSlot?` (index of earliest allowed slot), `evMaxPrice_cents_per_kWh?`
++ `evApplyPriceLimit?`, `evMinSoc_percent?`, `evOpportunisticLevel_percent?` +
+`evOpportunisticEnabled?` (and the type-2 pair), `evContinuous?`, plus the soft
+target controls below.
+
+### `api/services/config-builder.ts`
+
+Translate the new settings into `SolverConfig`: resolve `evStartTime` /
+`evDepartureTime` to slot indices over the plan horizon; pass price-limit, min
+SoC, opportunistic levels, and continuity through. Effective opportunistic cap =
+`max(targetSoc, opportunisticLevel, type2Level if enabled)` clamped to 100%.
+
+### `lib/build-lp.ts`
+
+1. **Earliest-start + ready window mask.** Force `ev_charge_t = 0` for
+   `t < evStartSlot` and `t > departureSlot` (the upper bound likely exists; add
+   the lower bound).
+2. **Price-limit mask.** When `evApplyPriceLimit`, force `ev_charge_t = 0` for
+   every slot whose import price exceeds `evMaxPrice_cents_per_kWh`. (Mask total
+   EV charge, not just `grid_to_ev`, to mirror the integration, which suppresses
+   charging entirely in over-limit slots.)
+3. **Soft target SoC.** Replace the hard "EV SoC ≥ target at departure" equality
+   with a soft constraint: introduce a non-negative shortfall variable
+   `ev_target_shortfall` with `ev_soc_departure + ev_target_shortfall ≥ target`
+   and add `BIG_PENALTY × ev_target_shortfall` to the objective. With a price
+   mask in place this keeps the model **feasible** when cheap slots are
+   insufficient, and the optimizer still hits the target whenever it can. Keep
+   the penalty well above any realistic energy price so target is honored unless
+   physically/price-mask blocked.
+4. **Minimum-SoC floor (hard).** Add `ev_soc_t ≥ evMinSoc_percent` for all slots
+   at/after the first slot in which the floor is physically reachable from the
+   starting SoC at max power. Min SoC is a safety floor and is **not** subject to
+   the price mask — exempt min-SoC-driven charging slots from the mask (e.g. a
+   dedicated `ev_floor_charge_t` term, or relax the mask until the floor is met).
+5. **Opportunistic value band.** For SoC above target up to the opportunistic
+   cap, add a small **negative cost** (reward) on stored EV energy valued at the
+   opportunistic price threshold, so the optimizer fills that band only when it
+   is cheap. Implement as a marginal value on the EV SoC band above target, not
+   as a constraint. Type 2 is a second band with its own (higher) cap; value it
+   at most the same or a configurable threshold.
+6. **Continuity penalty (MILP, optional / phase 2).** OptiVolt already uses MILP
+   binaries (CV phase). Reuse the EV on/off binary `ev_on_t` and add transition
+   variables capturing `ev_on_t XOR ev_on_{t-1}`; penalize the count of
+   transitions with a small objective weight when `evContinuous`. This biases the
+   solver toward one contiguous block without hard-forcing it.
+
+### `lib/parse-solution.ts`
+
+Surface the new outputs: `ev_soc_percent` already exists; add `ev_target_met`
+(boolean from shortfall ≈ 0) and ensure `ev_charge_mode` reflects planned vs
+opportunistic vs floor (`planned` / `opportunistic` / `min_soc`). The
+override-driven modes (`low_price`, `low_soc`, `keep_on`) are assigned in the
+runtime layer, not here.
+
+### `lib/dess-mapper.ts`
+
+No structural change required — it already consumes EV flows and applies EV
+discharge constraints. Verify the soft-target change does not alter the mapping
+contract (the mapper reads realized `ev_charge`, not the target).
+
+---
+
+## Runtime-override layer
+
+### New `api/services/ev-decision-service.ts`
+
+`computeEvDecision(settings, lastPlan)` → the **effective current decision**:
+
+1. Read live EV SoC (from `evSocSensor` via `fetchHaEntityState`) and the current
+   buy price (from the price source already used by the planner / the current
+   plan row). Read plug status (`evPlugSensor`) if present.
+2. Determine the active mode by priority:
+   - If `evLowSocChargingEnabled` and `liveSoc < evLowSocChargingLevel_percent`
+     → mode `low_soc`, charge at max power.
+   - Else if `evLowPriceChargingEnabled` and
+     `currentPrice ≤ evLowPriceChargingLevel_cents_per_kWh` → mode `low_price`,
+     charge at max power.
+   - Else if min-SoC floor not yet met → mode `min_soc`, charge at max power.
+   - Else fall back to the planned decision from `lastPlan` for the current slot
+     (`planned` / `opportunistic` / idle).
+   - `evKeepOn`: if charging is active and within the charge window, do not drop
+     to idle between planned slots — hold on until ready time / target.
+3. Respect plug status: if not connected and the override is not configured to
+   force regardless, report idle (mirror `alwaysApplySchedule` behavior — add an
+   equivalent for native mode, e.g. overrides require plug-connected unless a
+   future "force" flag says otherwise).
+4. Return `{ mode, is_charging, ev_charge_W, ev_charge_A, reason }`.
+
+### `api/routes/ev.ts` changes
+
+- `GET /ev/current`: replace the raw "current plan row" with
+  `computeEvDecision(...)` output (so low-price/low-SoC overrides are reflected
+  live). Keep returning the plan-derived flow split for context.
+- `GET /ev/schedule`: annotate each future slot with the mode it would take under
+  the overrides given forecast price (e.g. mark slots with
+  `price ≤ lowPriceLevel` as `low_price` when that switch is on), so the HA side
+  and the EV tab can preview reactive behavior. The planned charge stays the LP
+  result; the annotation is advisory.
+- Add `GET /ev/status` (optional): a compact `{ mode, is_charging, liveSoc,
+  targetSoc, targetMet, readyBy }` object convenient for a single HA sensor.
+
+---
+
+## Front-end changes
+
+### EV settings controls (`app/index.html`)
+
+Add controls to the **EV tab** Settings card (`panel-ev`) and/or the Settings-tab
+"EV Charging" card, using existing `toggle` / `form-input` / `sidebar-label`
+styles and the `data-settings-input` auto-persist convention. Group as:
+
+- **Window**: earliest-start (`datetime-local`, optional), ready-by (exists),
+  target SoC (exists), minimum SoC (number %).
+- **Price**: apply-price-limit toggle + max price (¢/kWh) number.
+- **Opportunistic**: enable toggle + level (%), plus type-2 enable + level.
+- **Reactive overrides**: low-price toggle + level (¢/kWh); low-SoC toggle +
+  level (%); keep-charger-on toggle.
+- **Behavior**: continuous-charging toggle.
+- **Source**: a small select for `evSource` (`native` default / `haSchedule`
+  legacy) — when `haSchedule`, hide the native-only controls and show the
+  existing `EvConfig` schedule-sensor fields.
+- Show the derived **charging speed (%/h)** as a read-only hint next to the
+  power/current fields.
+
+Each new control needs: the element id, registration in
+`app/src/ui-binding.js` (`getElements()`), hydrate in `app/src/state.js`
+(`hydrateUI`), and inclusion in `snapshotUI()` so it round-trips through
+`POST /settings`. Mirror how the existing EV fields are wired.
+
+### EV tab status (`app/src/ev-tab.js`, `app/src/ev-settings.js`)
+
+- Show a **mode badge** on the EV status card driven by `GET /ev/current` /
+  `GET /ev/status`: `Planned` / `Low price` / `Low SoC` / `Min SoC` /
+  `Opportunistic` / `Keep on` / `Idle`, colour-coded (reuse emerald for active
+  charging, a price-tint via `getBuyPriceColor` for low-price, amber for low-SoC).
+- Add a "Target met by ready time" indicator (green check / shortfall amount)
+  from `ev_target_met` / shortfall.
+- Keep the existing split bar, cost, and per-slot mode rows; extend the mode-row
+  colouring to include the new modes.
+
+---
+
+## Phases
+
+| Phase | Scope | Output |
+|-------|-------|--------|
+| 1 | Settings: new EV fields + defaults + schema; UI inputs wired (no behavior yet) | Settings round-trip; controls visible |
+| 2 | LP masks: earliest-start + price limit; soft target SoC | Plan respects window + price ceiling; stays feasible |
+| 3 | Minimum-SoC floor | EV guaranteed to reach min SoC ASAP, mask-exempt |
+| 4 | Runtime overrides: low-price + low-SoC + keep-on in `ev-decision-service` + `/ev/current` | Live decision flips to override modes correctly |
+| 5 | Opportunistic value bands (incl. type 2) | EV tops up beyond target only when cheap |
+| 6 | EV tab mode badge + target-met indicator + schedule annotation | UI surfaces active/forecast mode |
+| 7 (optional) | Continuous-charging MILP contiguity penalty | Fewer charge on/off cycles when enabled |
+| 8 | HA actuation glue documented + sample automation (Appendix) | HA drives charger from OptiVolt decision |
+
+Phases 1–6 reach functional parity for the requested low-price / low-SoC / price
+limit / min SoC / opportunistic settings. 7 is a refinement; 8 is the HA-side
+companion.
+
+---
+
+## Testing
+
+Per `AGENTS.md`: `npm run typecheck`, `npm run lint`, `npm run test:run`.
+
+- **`lib/build-lp.ts`** (pure unit tests, `tests/lib/`): price-mask zeros EV
+  charge in over-limit slots; earliest-start mask; soft target stays feasible
+  when cheap slots are insufficient and still hits target when they are
+  sufficient; min-SoC floor reached at the earliest feasible slot and exempt
+  from the price mask; opportunistic band only fills below its price threshold.
+- **`ev-decision-service`** (`tests/api/`): priority ordering
+  (low-SoC > low-price > min-SoC floor > planned); plug-status gating; mode +
+  power returned; tolerant of missing HA (falls back to planned).
+- **Route tests**: `/ev/current` reflects overrides; `/ev/schedule` annotations;
+  `/ev/status` shape.
+- **Browser** (`tests/app/`): new settings inputs hydrate and snapshot; mode
+  badge renders per `/ev/current`; `haSchedule` source hides native controls.
+
+If a release is cut, bump the 3 version files + `CHANGELOG.md` per `CLAUDE.md`.
+
+---
+
+## Acceptance criteria
+
+- The EV screen exposes **low-price charging** and **low-SoC charging** (toggles
+  + levels) plus price limit, minimum SoC, opportunistic (×2), continuous,
+  keep-on, and an earliest-start window — matching EV Smart Charging's feature
+  set.
+- Day-ahead planning honors the earliest-start window and price ceiling, reaches
+  minimum SoC as a hard floor, hits target SoC when feasible (soft otherwise),
+  and tops up opportunistically only when cheap.
+- The live decision (`/ev/current`) flips to **low-SoC** then **low-price**
+  overrides by priority, reacting to live SoC and price without re-solving; the
+  EV tab shows the active mode.
+- OptiVolt remains plan-only; an HA automation actuates the charger from the
+  `/ev/*` endpoints (Appendix). The legacy `haSchedule` reader still works when
+  selected.
+- `npm run typecheck`, `npm run lint`, and `npm run test:run` pass.
+
+---
+
+## Appendix: Home Assistant actuation glue
+
+OptiVolt plans; HA drives the charger. This glue lives in the
+`vervoto1/homeassistant` repo, documented here for completeness.
+
+- Expose OptiVolt's decision to HA as a REST sensor polling
+  `http://optivolt:3000/ev/status` (or `/ev/current`), surfacing `mode`,
+  `is_charging`, and `ev_charge_A`.
+- An HA automation reacts to that sensor: start/stop the Tesla Wall Connector and
+  set charging current to `ev_charge_A` when `is_charging` is true; stop
+  otherwise. The current EV Smart Charging integration can be retired, or kept in
+  a passive/manual mode purely as the charger-control shim while OptiVolt owns
+  planning.
+- Keep the JK BMS safety automation (Victron max charge current) unchanged; it is
+  independent of EV planning.
+- Because the charger sits behind the Victron inverter, EV draw already affects
+  grid import/export in the LP — no extra coupling is needed beyond the existing
+  EV flow variables.


### PR DESCRIPTION
Two self-contained build briefs (in `plans/`) for integrating both features into OptiVolt, written so a fresh Claude Code session can implement each from a single file.

## `plans/ess-dashboard-tab-plan.md`
New **ESS** tab between EV and Predictions. Multi-battery (config-driven, defaults seeded for the two JK BMS units + Victron system), cell-voltage snapshot/trend, temperatures, SoC development, and a system card. Reuses existing `ha-client.ts` (`fetchHaEntityState` + `fetchHaStats`) and the Chart.js / `card` styling. New `/ess/state` + `/ess/history` routes, `ess-service.ts`, `ess-tab.js`, tab wiring in `main.js`.

## `plans/ev-native-charging-plan.md`
Full **EV Smart Charging** feature parity in OptiVolt, then full independence from the integration:
- Decision parity (phases 1-6): low-price + low-SoC charging, price limit, minimum SoC, opportunistic (x2), continuous, keep-on, earliest-start window. Split across the LP planning layer (masks, soft target SoC, min-SoC floor, opportunistic value bands, MILP contiguity) and a runtime-override layer (`ev-decision-service.ts`).
- Actuation (phases 8-9): a `callHaService` write path in `ha-client.ts` + an `ev-actuator-service.ts` fast control tick that drives the charger via HA service calls, idempotently and fail-safe (no charger write on error/restart, single owner). This lets the EV Smart Charging integration be uninstalled. A plan-only + HA-automation path is kept as a fallback.

Docs only, no code changes. Each plan is phased with file lists, type snippets, LP formulation, UI specs, tests, and acceptance criteria.

Generated with Claude Code.
