### PR TITLE
Fix EV three-phase charge power (0.7.27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.27 - 2026-06-13
+
+- **Fix:** Model three-phase EV charge power. The amps↔watts conversion was hardcoded single-phase (`current_A × 230`) in `config-builder.ts` and `parse-solution.ts`, so a three-phase charger (e.g. an 11 kW Tesla Wall Connector at 16 A) was planned and read back at ~3.7 kW — about a third of real power — causing the LP to under-schedule EV charging and report a wrong `ev_charge_A`. Added an `evChargePhases` setting (1 or 3) threaded through `EvConfig`, with a single source of truth `AC_PHASE_VOLTAGE_V` (230 V) so the amps→watts (config-builder) and watts→amps (parse-solution) sites always agree: `watts = amps × 230 × phases`. Exposed as a "Charger phases" selector in the EV Charging settings card. **Default is three-phase** (the target hardware); single-phase deployments must set `evChargePhases = 1`, and callers that omit the field fall back to single-phase.
+- **Chore:** Bump `vitest` and `@vitest/coverage-v8` to 4.1.8 (test tooling only).
+
 ## 0.7.26 - 2026-06-05
 
 - **Fix:** Drop implausible energy-counter spikes from Home Assistant statistics before they reach the load/PV predictor. A meter reset on 2026-05-30 (coinciding with a Venus MQTT update) recorded one period as ~4296 kWh; under `mean` aggregation this averaged into a ~538 kWh forecast load for a single slot, which exceeded the grid import cap and made the LP **infeasible** — producing an empty schedule. `postprocess()` now discards any per-period reading whose magnitude exceeds `MAX_PLAUSIBLE_SLOT_ENERGY_WH` (25 kWh, overridable via the new `{ maxSlotEnergyWh }` option) and logs a `[ha-postprocess]` warning naming the sensor, timestamp, and value. The dropped sample becomes a gap, which the historical predictor already skips, so it no longer poisons the mean/median or the auto-tuner's validation metrics.

--- a/api/defaults/default-settings.json
+++ b/api/defaults/default-settings.json
@@ -98,6 +98,7 @@
   "evEnabled": false,
   "evMinChargeCurrent_A": 6,
   "evMaxChargeCurrent_A": 16,
+  "evChargePhases": 3,
   "evBatteryCapacity_kWh": 60,
   "evSocSensor": "",
   "evPlugSensor": "",

--- a/api/services/config-builder.ts
+++ b/api/services/config-builder.ts
@@ -6,6 +6,7 @@ import { applyPredictionAdjustmentsToData, pruneExpiredPredictionAdjustments } f
 import { recordFullSocObservation } from './rebalance-nudge.ts';
 import { extractWindow, getQuarterStart, getSeriesEndMs } from '../../lib/time-series-utils.ts';
 import { fetchHaEntityState } from './ha-client.ts';
+import { AC_PHASE_VOLTAGE_V } from '../../lib/build-lp.ts';
 import type { SolverConfig, EvConfig } from '../../lib/types.ts';
 import type { Settings, Data, CalibrationResult } from '../types.ts';
 
@@ -116,8 +117,12 @@ export function buildSolverConfigFromSettings(
 
   if (settings.evEnabled && evState?.pluggedIn) {
     const T = base.load_W.length;
-    const minPow_W = settings.evMinChargeCurrent_A * 230;
-    const maxPow_W = settings.evMaxChargeCurrent_A * 230;
+    // Three-phase chargers deliver 3x the power per amp. Single source for the
+    // A->W conversion; parse-solution does the inverse with the same phase count.
+    const phases = settings.evChargePhases === 3 ? 3 : 1;
+    const wattsPerAmp = AC_PHASE_VOLTAGE_V * phases;
+    const minPow_W = settings.evMinChargeCurrent_A * wattsPerAmp;
+    const maxPow_W = settings.evMaxChargeCurrent_A * wattsPerAmp;
     const capacityWh = settings.evBatteryCapacity_kWh * 1000;
     const stepHours = settings.stepSize_m / 60;
 
@@ -138,6 +143,7 @@ export function buildSolverConfigFromSettings(
         evTargetSoc_percent: (achievableTargetWh / capacityWh) * 100,
         evDepartureSlot: D,
         evChargeEfficiency_percent: settings.evChargeEfficiency_percent,
+        evChargePhases: phases,
       };
       base.ev = ev;
     }

--- a/api/services/settings-schema.ts
+++ b/api/services/settings-schema.ts
@@ -210,6 +210,9 @@ export function normalizeSettings(settings: Settings): Settings {
   if (normalized.evMaxChargeCurrent_A < normalized.evMinChargeCurrent_A) {
     [normalized.evMinChargeCurrent_A, normalized.evMaxChargeCurrent_A] = [normalized.evMaxChargeCurrent_A, normalized.evMinChargeCurrent_A];
   }
+  // EV charger AC phases: only 1 or 3 are meaningful. Default to 3 (the target
+  // hardware is a three-phase Wall Connector); single-phase users set 1.
+  normalized.evChargePhases = Number(normalized.evChargePhases) === 1 ? 1 : 3;
   normalized.evBatteryCapacity_kWh = Math.max(
     0,
     Number.isFinite(normalized.evBatteryCapacity_kWh) ? normalized.evBatteryCapacity_kWh : 0,

--- a/api/types.ts
+++ b/api/types.ts
@@ -57,6 +57,8 @@ export interface Settings {
   evEnabled: boolean;
   evMinChargeCurrent_A: number;
   evMaxChargeCurrent_A: number;
+  /** AC phases the EV charger uses (1 or 3). Three-phase delivers 3x the power per amp. */
+  evChargePhases: number;
   evBatteryCapacity_kWh: number;
   evSocSensor: string;
   evPlugSensor: string;

--- a/app/index.html
+++ b/app/index.html
@@ -1891,6 +1891,14 @@
               </label>
             </div>
             <div class="grid grid-cols-2 gap-3">
+              <label class="block text-sm">Charger phases
+                <select id="ev-charge-phases" class="form-input" data-settings-input>
+                  <option value="1">1-phase (×230 V)</option>
+                  <option value="3">3-phase (×3 × 230 V)</option>
+                </select>
+              </label>
+            </div>
+            <div class="grid grid-cols-2 gap-3">
               <label class="block text-sm">EV battery capacity (kWh)
                 <input id="ev-battery-capacity" type="number" min="1" step="0.1"
                   class="form-input" data-settings-input />

--- a/app/src/state.js
+++ b/app/src/state.js
@@ -123,6 +123,7 @@ export function snapshotUI(els) {
     evEnabled: !!els.evEnabled?.checked,
     evMinChargeCurrent_A: num(els.evMinChargeCurrent?.value),
     evMaxChargeCurrent_A: num(els.evMaxChargeCurrent?.value),
+    evChargePhases: num(els.evChargePhases?.value),
     evBatteryCapacity_kWh: num(els.evBatteryCapacity?.value),
     evChargeEfficiency_percent: num(els.evChargeEfficiency?.value),
     evDepartureTime: els.evDepartureTime?.value ?? '',
@@ -211,6 +212,7 @@ export function hydrateUI(els, obj = {}) {
   }
   setIfDef(els.evMinChargeCurrent, obj.evMinChargeCurrent_A);
   setIfDef(els.evMaxChargeCurrent, obj.evMaxChargeCurrent_A);
+  setIfDef(els.evChargePhases, obj.evChargePhases);
   setIfDef(els.evBatteryCapacity, obj.evBatteryCapacity_kWh);
   setIfDef(els.evChargeEfficiency, obj.evChargeEfficiency_percent);
   setIfDef(els.evDepartureTime, obj.evDepartureTime);

--- a/app/src/ui-binding.js
+++ b/app/src/ui-binding.js
@@ -152,6 +152,7 @@ export function getElements() {
     // EV Charging LP-based fields (Settings tab)
     evMinChargeCurrent: $("#ev-min-charge-current"),
     evMaxChargeCurrent: $("#ev-max-charge-current"),
+    evChargePhases: $("#ev-charge-phases"),
     evBatteryCapacity: $("#ev-battery-capacity"),
     evChargeEfficiency: $("#ev-charge-efficiency"),
     evDepartureTime: $("#ev-departure-time"),

--- a/lib/build-lp.ts
+++ b/lib/build-lp.ts
@@ -9,6 +9,14 @@ import type { SolverConfig, TerminalSocValuation } from './types.ts';
  */
 export const DEFAULT_INVERTER_EFFICIENCY_PERCENT = 95;
 
+// AC line voltage per phase, used to convert EV charge current (A) <-> power (W).
+// A single-phase charger delivers `A * AC_PHASE_VOLTAGE_V` watts; a three-phase
+// charger delivers `A * AC_PHASE_VOLTAGE_V * 3`. The phase count is per-config
+// (EvConfig.evChargePhases), so this constant is the single source for both the
+// amps->watts conversion (config-builder) and the watts->amps conversion
+// (parse-solution).
+export const AC_PHASE_VOLTAGE_V = 230;
+
 /*
  * LP unit conventions
  * ───────────────────

--- a/lib/parse-solution.ts
+++ b/lib/parse-solution.ts
@@ -1,7 +1,5 @@
 import type { PlanRow, SolverConfig, EvChargeMode } from './types.ts';
-import { DEFAULT_INVERTER_EFFICIENCY_PERCENT } from './build-lp.ts';
-
-const EV_CHARGE_VOLTAGE_V = 230; // single-phase AC voltage assumed for A conversion
+import { DEFAULT_INVERTER_EFFICIENCY_PERCENT, AC_PHASE_VOLTAGE_V } from './build-lp.ts';
 
 // Minimal type for the HiGHS solver result columns (keyed by variable name).
 interface HighsColumn {
@@ -27,6 +25,10 @@ export function parseSolution(result: HighsSolution, cfg: SolverConfig, opts: Pa
   const cap = Math.max(1e-9, cfg.batteryCapacity_Wh);
   // v8 ignore next — trivial Math.max always true branch in practice
   const evCap = Math.max(1e-9, cfg.ev?.evBatteryCapacity_Wh ?? 1);
+  // Watts-per-amp for the EV charge-current readout. Must match the amps->watts
+  // factor config-builder used (AC_PHASE_VOLTAGE_V * phases). Defaults to
+  // single-phase when the phase count is absent.
+  const evWattsPerAmp = AC_PHASE_VOLTAGE_V * (cfg.ev?.evChargePhases === 3 ? 3 : 1);
   // Inverter efficiency: variables that cross the DC→AC boundary in the LP are
   // emitted as DC W; downstream consumers (plan-summary, plan-accuracy, DESS
   // mapper, UI) expect AC-side numbers matching the AC meter VRM reports.
@@ -123,7 +125,7 @@ export function parseSolution(result: HighsSolution, cfg: SolverConfig, opts: Pa
       pv2ev:         round(pv2ev_AC),
       b2ev:          round(b2ev_AC),
       ev_charge:     round(evW),
-      ev_charge_A:   round(evW / EV_CHARGE_VOLTAGE_V),
+      ev_charge_A:   round(evW / evWattsPerAmp),
       ev_charge_mode: evChargeMode(g2ev[t], pv2ev_AC, b2ev_AC, cfg.ev?.evMinChargePower_W ?? 0, pv2b[t]),
       ev_soc_percent: (evSoc[t] / evCap) * 100,
     });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -24,6 +24,12 @@ export interface EvConfig {
   evDepartureSlot: number;
   /** AC-to-DC efficiency of the EV's onboard charger, as a percentage (e.g. 90 = 90%). */
   evChargeEfficiency_percent: number;
+  /**
+   * Number of AC phases the charger uses (1 or 3). Sets the A<->W conversion:
+   * watts = amps * AC_PHASE_VOLTAGE_V * evChargePhases. Defaults to 1 (single-phase)
+   * when omitted so existing callers keep their prior behavior.
+   */
+  evChargePhases?: number;
 }
 
 /**
@@ -132,7 +138,7 @@ export interface PlanRow {
   pv2ev: number;        // PV → EV W
   b2ev: number;         // battery → EV W
   ev_charge: number;    // total EV charge power W
-  ev_charge_A: number;  // charge current A (ev_charge / 230 / phases)
+  ev_charge_A: number;  // charge current A (ev_charge / (AC_PHASE_VOLTAGE_V * evChargePhases))
   ev_charge_mode: EvChargeMode;
   ev_soc_percent: number;  // EV SoC %
 }

--- a/optivolt/config.yaml
+++ b/optivolt/config.yaml
@@ -1,6 +1,6 @@
 name: Optivolt
 slug: optivolt
-version: "0.7.26"
+version: "0.7.27"
 description: Plan and control Victron ESS with forecasts & dynamic tariffs!
 url: https://github.com/vervoto1/optivolt
 image: "ghcr.io/vervoto1/{arch}-addon-optivolt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optivolt",
-  "version": "0.7.26",
+  "version": "0.7.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optivolt",
-      "version": "0.7.26",
+      "version": "0.7.27",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@eslint/js": "^10.0.1",
         "@eslint/markdown": "^8.0.1",
         "@types/express": "^5.0.6",
-        "@vitest/coverage-v8": "^4.1.7",
+        "@vitest/coverage-v8": "^4.1.8",
         "dotenv-cli": "^11.0.0",
         "eslint": "^10.3.0",
         "globals": "^17.6.0",
@@ -26,7 +26,7 @@
         "nodemon": "^3.1.14",
         "supertest": "^7.2.2",
         "typescript": "^6.0.3",
-        "vitest": "^4.1.7"
+        "vitest": "^4.1.8"
       },
       "engines": {
         "node": "^22.13.0 || >=24"
@@ -621,9 +621,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
-      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -639,9 +639,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
-      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -655,9 +655,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
-      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -671,9 +671,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
-      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -687,9 +687,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
-      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -703,9 +703,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
-      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -719,9 +719,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
-      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -735,9 +735,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
-      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -751,9 +751,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
-      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -767,9 +767,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
-      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -783,9 +783,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
-      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -799,9 +799,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
-      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -815,9 +815,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
-      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
-      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -849,9 +849,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
-      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -865,9 +865,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
-      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -1085,13 +1085,13 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
-      "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.7",
+        "@vitest/utils": "4.1.8",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -1105,8 +1105,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.7",
-        "vitest": "4.1.7"
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1115,15 +1115,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
-      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
       "dev": true,
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1132,12 +1132,12 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
-      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "4.1.7",
+        "@vitest/spy": "4.1.8",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1158,9 +1158,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
-      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
       "dependencies": {
         "tinyrainbow": "^3.1.0"
@@ -1170,12 +1170,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
-      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "4.1.7",
+        "@vitest/utils": "4.1.8",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1183,13 +1183,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
-      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1198,21 +1198,21 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
-      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
       "dev": true,
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
-      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "4.1.7",
+        "@vitest/pretty-format": "4.1.8",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -4633,12 +4633,12 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
     },
     "node_modules/rolldown": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
-      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "dependencies": {
-        "@oxc-project/types": "=0.132.0",
+        "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -4648,21 +4648,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.2",
-        "@rolldown/binding-darwin-arm64": "1.0.2",
-        "@rolldown/binding-darwin-x64": "1.0.2",
-        "@rolldown/binding-freebsd-x64": "1.0.2",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
-        "@rolldown/binding-linux-arm64-musl": "1.0.2",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-musl": "1.0.2",
-        "@rolldown/binding-openharmony-arm64": "1.0.2",
-        "@rolldown/binding-wasm32-wasi": "1.0.2",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
-        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/router": {
@@ -5018,9 +5018,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "dependencies": {
         "fdir": "^6.5.0",
@@ -5310,16 +5310,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
-      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.15",
-        "rolldown": "1.0.2",
-        "tinyglobby": "^0.2.16"
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -5399,18 +5399,18 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
-      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "dependencies": {
-        "@vitest/expect": "4.1.7",
-        "@vitest/mocker": "4.1.7",
-        "@vitest/pretty-format": "4.1.7",
-        "@vitest/runner": "4.1.7",
-        "@vitest/snapshot": "4.1.7",
-        "@vitest/spy": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -5438,12 +5438,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.7",
-        "@vitest/browser-preview": "4.1.7",
-        "@vitest/browser-webdriverio": "4.1.7",
-        "@vitest/coverage-istanbul": "4.1.7",
-        "@vitest/coverage-v8": "4.1.7",
-        "@vitest/ui": "4.1.7",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optivolt",
-  "version": "0.7.26",
+  "version": "0.7.27",
   "description": "Optivolt is a linear and mixed-integer optimizer for home energy systems.",
   "homepage": "https://github.com/bmesuere/optivolt#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@eslint/js": "^10.0.1",
     "@eslint/markdown": "^8.0.1",
     "@types/express": "^5.0.6",
-    "@vitest/coverage-v8": "^4.1.7",
+    "@vitest/coverage-v8": "^4.1.8",
     "dotenv-cli": "^11.0.0",
     "eslint": "^10.3.0",
     "globals": "^17.6.0",
@@ -44,6 +44,6 @@
     "nodemon": "^3.1.14",
     "supertest": "^7.2.2",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.8"
   }
 }

--- a/tests/api/services/config-builder.test.js
+++ b/tests/api/services/config-builder.test.js
@@ -696,6 +696,7 @@ const evSettings = {
   evEnabled: true,
   evMinChargeCurrent_A: 6,
   evMaxChargeCurrent_A: 16,
+  evChargePhases: 1, // explicit single-phase so the power assertions below are unambiguous
   evBatteryCapacity_kWh: 60,
   evDepartureTime: '2024-01-01T14:00:00Z', // 2 h after NOW_MS → 8 slots @ 15 min
   evTargetSoc_percent: 80,
@@ -730,6 +731,26 @@ describe('buildSolverConfigFromSettings — EV config', () => {
     expect(cfg.ev.evBatteryCapacity_Wh).toBe(60_000);
     expect(cfg.ev.evInitialSoc_percent).toBe(50);
     expect(cfg.ev.evDepartureSlot).toBe(8); // 2h / 15min = 8 slots
+    expect(cfg.ev.evChargePhases).toBe(1);
+  });
+
+  it('uses three-phase power (3x per amp) when evChargePhases is 3', () => {
+    const cfg = buildSolverConfigFromSettings(
+      { ...evSettings, evChargePhases: 3 }, makeData(), NOW_MS,
+      { pluggedIn: true, soc_percent: 50 },
+    );
+    expect(cfg.ev.evMinChargePower_W).toBe(6 * 230 * 3);   // 4140
+    expect(cfg.ev.evMaxChargePower_W).toBe(16 * 230 * 3);  // 11040 ≈ 11 kW
+    expect(cfg.ev.evChargePhases).toBe(3);
+  });
+
+  it('treats an unset/invalid evChargePhases as single-phase', () => {
+    const cfg = buildSolverConfigFromSettings(
+      { ...evSettings, evChargePhases: undefined }, makeData(), NOW_MS,
+      { pluggedIn: true, soc_percent: 50 },
+    );
+    expect(cfg.ev.evMaxChargePower_W).toBe(16 * 230); // falls back to ×230
+    expect(cfg.ev.evChargePhases).toBe(1);
   });
 
   it('clamps achievable target when max charge falls short of requested target', () => {

--- a/tests/app/state.test.js
+++ b/tests/app/state.test.js
@@ -642,6 +642,7 @@ describe('updateSummaryUI', () => {
     // Ensure flat EV fields exist in els
     els.evMinChargeCurrent = { value: '' };
     els.evMaxChargeCurrent = { value: '' };
+    els.evChargePhases = { value: '' };
     els.evBatteryCapacity = { value: '' };
     els.evChargeEfficiency = { value: '' };
     els.evDepartureTime = { value: '' };
@@ -652,6 +653,7 @@ describe('updateSummaryUI', () => {
       evEnabled: true,
       evMinChargeCurrent_A: 10,
       evMaxChargeCurrent_A: 32,
+      evChargePhases: 3,
       evBatteryCapacity_kWh: 60,
       evChargeEfficiency_percent: 90,
       evDepartureTime: '2024-01-15T08:00:00Z',
@@ -661,6 +663,7 @@ describe('updateSummaryUI', () => {
     });
     expect(els.evMinChargeCurrent.value).toBe('10');
     expect(els.evMaxChargeCurrent.value).toBe('32');
+    expect(els.evChargePhases.value).toBe('3');
     expect(els.evBatteryCapacity.value).toBe('60');
     expect(els.evChargeEfficiency.value).toBe('90');
     expect(els.evDepartureTime.value).toBe('2024-01-15T08:00:00Z');

--- a/tests/lib/parse-solution.test.js
+++ b/tests/lib/parse-solution.test.js
@@ -133,6 +133,37 @@ describe('parseSolution', () => {
 
 });
 
+describe('parseSolution — ev_charge_A phase conversion', () => {
+  const baseEv = {
+    evMinChargePower_W: 0,
+    evMaxChargePower_W: 11040,
+    evBatteryCapacity_Wh: 60000,
+    evInitialSoc_percent: 50,
+    evTargetSoc_percent: 80,
+    evDepartureSlot: 4,
+  };
+  const opts = { startMs: 1700000000000, stepMin: 15 };
+  // grid_to_ev is AC into the charger, so ev_charge ≈ g2ev (no inverter factor).
+  const result = {
+    Columns: {
+      'grid_to_ev_0': { Primal: 3450 }, // 15 A single-phase, or 5 A three-phase
+      'ev_soc_0':     { Primal: 30000 },
+    },
+  };
+
+  it('single-phase: 3450 W → 15 A (default when phases unset)', () => {
+    const cfg = { load_W: [500], pv_W: [0], importPrice: [10], exportPrice: [5], batteryCapacity_Wh: 1000, ev: baseEv };
+    const [row] = parseSolution(result, cfg, opts);
+    expect(row.ev_charge_A).toBeCloseTo(15, 3);
+  });
+
+  it('three-phase: 3450 W → 5 A (÷ 230 × 3)', () => {
+    const cfg = { load_W: [500], pv_W: [0], importPrice: [10], exportPrice: [5], batteryCapacity_Wh: 1000, ev: { ...baseEv, evChargePhases: 3 } };
+    const [row] = parseSolution(result, cfg, opts);
+    expect(row.ev_charge_A).toBeCloseTo(5, 3);
+  });
+});
+
 describe('parseSolution — ev_charge_mode derivation', () => {
   const evCfg = {
     load_W: [500],


### PR DESCRIPTION
## Problem
The EV amps↔watts conversion was hardcoded **single-phase** (`current_A × 230`) at the only two sites that do it:
- `api/services/config-builder.ts` (amps→watts when building the solver config)
- `lib/parse-solution.ts` (watts→amps for `ev_charge_A`)

The target charger is an **11 kW three-phase** Tesla Wall Connector, so at 16 A the model planned and read back ~3.7 kW — about a third of real power. The LP under-scheduled EV charging and `ev_charge_A` was wrong.

## Fix
- Add `evChargePhases` (1 | 3) to `Settings` and `EvConfig`.
- Single source of truth `AC_PHASE_VOLTAGE_V` (230) in `lib/build-lp.ts`; both sites compute `watts = amps × 230 × phases`, so build and parse always agree.
- Schema normalizes `evChargePhases` to 1 or 3.
- UI: a **"Charger phases"** selector in the EV Charging settings card (round-trips via `POST /settings` like the sibling EV fields).

| 16 A | before | after (3-phase) |
|---|---|---|
| `evMaxChargePower_W` | 3680 | **11040** (~11 kW) |
| `ev_charge_A` readback | `W/230` | `W/(230×3)` |

## ⚠️ Backward-compat
**Default is three-phase** (`default-settings.json`). Existing three-phase deployments become correct automatically (omitted field normalizes to 3). **Single-phase deployments must set `evChargePhases = 1`**, otherwise the LP assumes 3× EV power. Library callers that omit the field on `EvConfig` fall back to single-phase.

## Tests
- `config-builder`: 1-phase, 3-phase, and unset→1 fallback power assertions.
- `parse-solution`: `ev_charge_A` phase conversion (single vs three-phase).
- Existing single-phase assertions made phase-explicit.
- Full suite green (1443 tests), typecheck + lint clean.

## Release
Bumped to **0.7.27** across `package.json`, `package-lock.json`, `optivolt/config.yaml` (triggers a new HA add-on image), and `CHANGELOG.md`. Also folds in a pre-existing test-tooling bump (`vitest`/`@vitest/coverage-v8` 4.1.8) as its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)