### PR TITLE
fix(docker): pin deps stage to BUILDPLATFORM (fixes aarch64 QEMU crash)

### DIFF
--- a/optivolt/Dockerfile
+++ b/optivolt/Dockerfile
@@ -4,7 +4,12 @@ ARG BUILD_FROM
 #
 # Stage 1: install npm deps on the native builder platform to avoid QEMU
 # "Illegal instruction" crashes when cross-compiling for aarch64.
-FROM node:22-alpine AS deps
+# --platform=$BUILDPLATFORM pins this stage to the build host (amd64 runner) so
+# `npm ci` runs natively instead of under QEMU emulation. The runtime deps
+# (express, highs/WASM, mqtt) are arch-independent and dev-only native binaries
+# are stripped by `npm prune --omit=dev`, so the pruned node_modules copied into
+# the target-arch stage 2 below is portable across architectures.
+FROM --platform=$BUILDPLATFORM node:22-alpine AS deps
 WORKDIR /opt/optivolt
 COPY package.json package-lock.json* ./
 RUN npm_config_ignore_scripts=true npm ci \


### PR DESCRIPTION
The 0.7.28 publish build on `main` failed: the aarch64 image crashed with `qemu: uncaught target signal 4 (Illegal instruction)` / exit 132 during `npm ci` + `tsx install`.

**Root cause:** the deps stage comment says it installs on the *native* builder platform to avoid exactly this QEMU crash, but `FROM node:22-alpine AS deps` was never pinned. The HA builder therefore pulled the stage as `linux/arm64` and ran `npm ci` under QEMU emulation, which intermittently crashes (it happened to pass for #15, but it's a coin flip).

**Fix:** `FROM --platform=$BUILDPLATFORM node:22-alpine AS deps` — runs the install natively on the amd64 runner. Safe because the pruned, production-only `node_modules` (express, highs/WASM, mqtt — no native addons; dev-only `.node` binaries removed by `npm prune --omit=dev`) is arch-independent, which is the whole premise of the multi-stage copy into the target-arch stage 2. Bonus: the build is faster (no emulated npm).

No version change — merging re-triggers the Builder to publish `0.7.28` (which never landed on GHCR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)