### PR TITLE
Bump to 0.7.30 — essConfig sourced from defaults (fix stale calibration tiles / refresh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.30 - 2026-06-13
+
+- **Fix:** ESS dashboard config (`essConfig`) is now sourced authoritatively from `default-settings.json`; a persisted `essConfig` in `settings.json` is ignored. `saveSettings` persists the whole settings object, so the seeded `essConfig` got written to `settings.json` the first time any setting was saved on 0.7.28 — and that stale copy then overrode later default changes (e.g. the 0.7.29 removal of the write-only current/voltage **calibration** tiles and the 30 s → 5 s refresh interval kept showing the old values). Since there is no UI to edit `essConfig` yet, defaults are the single source of truth; this will become a real merge again when an `essConfig` editor is added.
+
 ## 0.7.29 - 2026-06-13
 
 - **ESS dashboard polish:**

--- a/api/services/settings-store.ts
+++ b/api/services/settings-store.ts
@@ -36,16 +36,14 @@ export async function loadSettings(): Promise<Settings> {
           ...(settings.pvCurtailment ?? {}),
         } as Settings['pvCurtailment']
       : undefined;
-    // Deep-merge essConfig so newly-added default scalar fields survive on top
-    // of a persisted block, while persisted batteries/system/entities win.
-    // Without this, the shallow {...defaults, ...settings} below would replace
-    // the whole block and a persisted essConfig would never pick up new defaults.
-    const mergedEssConfig = (defaults.essConfig || settings.essConfig)
-      ? {
-          ...(defaults.essConfig ?? {}),
-          ...(settings.essConfig ?? {}),
-        } as Settings['essConfig']
-      : undefined;
+    // essConfig is server-owned and has no settings UI yet, so
+    // default-settings.json is authoritative — ignore any persisted essConfig.
+    // A persisted copy gets written whenever the user saves unrelated settings
+    // (saveSettings persists the whole object), and would otherwise pin stale
+    // entities/cadence and silently override updates to the seeded config — e.g.
+    // removed calibration tiles or a changed refresh interval would never apply.
+    // (When a Phase 7 essConfig editor lands, this can become a real merge.)
+    const mergedEssConfig = defaults.essConfig;
     const merged = {
       ...defaults,
       ...settings,

--- a/optivolt/config.yaml
+++ b/optivolt/config.yaml
@@ -1,6 +1,6 @@
 name: Optivolt
 slug: optivolt
-version: "0.7.29"
+version: "0.7.30"
 description: Plan and control Victron ESS with forecasts & dynamic tariffs!
 url: https://github.com/vervoto1/optivolt
 image: "ghcr.io/vervoto1/{arch}-addon-optivolt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optivolt",
-  "version": "0.7.29",
+  "version": "0.7.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optivolt",
-      "version": "0.7.29",
+      "version": "0.7.30",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optivolt",
-  "version": "0.7.29",
+  "version": "0.7.30",
   "description": "Optivolt is a linear and mixed-integer optimizer for home energy systems.",
   "homepage": "https://github.com/bmesuere/optivolt#readme",
   "bugs": {

--- a/tests/api/services/settings-store.test.js
+++ b/tests/api/services/settings-store.test.js
@@ -218,6 +218,38 @@ describe('loadSettings — validateSettings edge cases', () => {
   });
 });
 
+describe('loadSettings — essConfig is defaults-authoritative', () => {
+  beforeEach(() => {
+    _reset();
+  });
+
+  const baseEss = (overrides = {}) => ({
+    enabled: true,
+    historyWindowHours: 24,
+    historyPeriod: '5minute',
+    refreshIntervalSeconds: 5,
+    batteries: [{ name: 'Default Batt' }],
+    ...overrides,
+  });
+
+  it('ignores a persisted essConfig and uses the default (so stale entities/cadence cannot pin)', async () => {
+    _set(getDefaultPath(), makeDefaults({ essConfig: baseEss() }));
+    // Persisted copy carries stale calibration extras and a stale 30s interval.
+    _set('/tmp/test-data/settings.json', {
+      essConfig: baseEss({
+        refreshIntervalSeconds: 30,
+        batteries: [{ name: 'Stale Batt', extraEntities: [{ entity: 'number.x_current_calibration', name: 'Current calibration' }] }],
+      }),
+    });
+
+    const settings = await loadSettings();
+
+    expect(settings.essConfig.batteries.map(b => b.name)).toEqual(['Default Batt']);
+    expect(settings.essConfig.batteries[0].extraEntities).toBeUndefined();
+    expect(settings.essConfig.refreshIntervalSeconds).toBe(5);
+  });
+});
+
 describe('saveSettings', () => {
   beforeEach(() => {
     _reset();


### PR DESCRIPTION
**Symptom:** the current/voltage calibration tiles (removed in 0.7.29) were still showing, and the refresh interval was still 30 s instead of 5 s.

**Cause:** `saveSettings` persists the *whole* settings object, so the seeded `essConfig` got written into `settings.json` the first time any setting was saved on 0.7.28. `loadSettings` then deep-merged `{...defaults.essConfig, ...persisted.essConfig}`, so the **stale persisted copy won** and silently overrode later default changes.

**Fix:** `essConfig` has no settings UI yet, so `default-settings.json` is now authoritative — `loadSettings` ignores any persisted `essConfig`. This delivers the 0.7.29 calibration removal and the 5 s refresh to instances that had already saved settings, and prevents the whole class of "stale persisted essConfig overrides defaults" bugs. When an `essConfig` editor is added (Phase 7), this becomes a real merge again. Added a regression test.

lint + typecheck + 1490 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)