### PR TITLE
v0.7.33 fix(ev): plan EV charging when no "Ready by" deadline is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.33 - 2026-06-14
+
+- **Fix: plan EV charging when no "Ready by" deadline is set.** Native EV planning only runs when there is a valid charge window. With "Ready by" left empty, the window collapsed to zero slots and the EV was dropped from the plan entirely — so the schedule showed no EV charging and the EV SoC chart read 0% even with the car connected at a known SoC. An unset "Ready by" now defaults to the **end of the known price horizon** (reach target by the last slot we have prices for, charging in the cheapest hours along the way). The plug gate is unchanged: the EV is still only folded into the home-battery co-optimization when it is actually connected, so the home-battery plan never prepares for an EV draw that won't happen.
+
 ## 0.7.32 - 2026-06-14
 
 - **Remove the legacy HA-schedule EV mode and reorganize EV settings.** With native EV planning now the way OptiVolt charges (0.7.31), the alternate "EV Smart Charging schedule reader" mode it replaced is removed, and the EV-related settings move out of the day-to-day EV tab.

--- a/api/services/config-builder.ts
+++ b/api/services/config-builder.ts
@@ -145,7 +145,13 @@ export function buildSolverConfigFromSettings(
     const maxPow_W = settings.evMaxChargeCurrent_A * wattsPerAmp;
     const capacityWh = settings.evBatteryCapacity_kWh * 1000;
 
-    const D = departureTimeToSlot(settings.evDepartureTime, nowMs, settings.stepSize_m, T);
+    // "Ready by" deadline. When the user has not set one, default to the end of
+    // the known horizon — i.e. reach target by the last slot we have prices for,
+    // charging in the cheapest hours along the way. (Only reached when the EV is
+    // connected, so the home-battery co-optimisation still ignores an absent EV.)
+    const D = settings.evDepartureTime?.trim()
+      ? departureTimeToSlot(settings.evDepartureTime, nowMs, settings.stepSize_m, T)
+      : T;
     // Earliest-start window: slot index at/after which charging is allowed.
     const startSlot = startTimeToSlot(settings.evStartTime, nowMs, settings.stepSize_m);
 

--- a/optivolt/config.yaml
+++ b/optivolt/config.yaml
@@ -1,6 +1,6 @@
 name: Optivolt
 slug: optivolt
-version: "0.7.32"
+version: "0.7.33"
 description: Plan and control Victron ESS with forecasts & dynamic tariffs!
 url: https://github.com/vervoto1/optivolt
 image: "ghcr.io/vervoto1/{arch}-addon-optivolt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optivolt",
-  "version": "0.7.32",
+  "version": "0.7.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optivolt",
-      "version": "0.7.32",
+      "version": "0.7.33",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optivolt",
-  "version": "0.7.32",
+  "version": "0.7.33",
   "description": "Optivolt is a linear and mixed-integer optimizer for home energy systems.",
   "homepage": "https://github.com/bmesuere/optivolt#readme",
   "bugs": {

--- a/tests/api/services/config-builder.test.js
+++ b/tests/api/services/config-builder.test.js
@@ -759,6 +759,17 @@ describe('buildSolverConfigFromSettings — EV config', () => {
     expect(cfg.ev.evChargePhases).toBe(1);
   });
 
+  it('defaults the departure deadline to the end of the horizon when "ready by" is unset', () => {
+    // No evDepartureTime → charge across the full known horizon, reaching target
+    // by the last slot. (Still gated on a connected EV via evState.pluggedIn.)
+    const cfg = buildSolverConfigFromSettings(
+      { ...evSettings, evDepartureTime: '' }, makeData(), NOW_MS,
+      { pluggedIn: true, soc_percent: 50 },
+    );
+    expect(cfg.ev).toBeDefined();
+    expect(cfg.ev.evDepartureSlot).toBe(cfg.load_W.length);
+  });
+
   it('passes the REQUESTED target through unclamped (capacity-only; soft target carries feasibility)', () => {
     // The old achievable-charge clamp silently lowered the target before the LP
     // saw it, so the (now soft) target read as "met" while the car sat below the

--- a/tests/lib/ev-native-charging.test.js
+++ b/tests/lib/ev-native-charging.test.js
@@ -56,6 +56,22 @@ describe('EV native charging — soft target', () => {
     expect(dep.ev_target_shortfall_Wh).toBeLessThan(2);
   });
 
+  it('anchors the SoC trajectory to the initial SoC for a small deficit (78% -> 80%)', () => {
+    // Regression for the "EV SoC graph shows 0% while the car is at 78%" report:
+    // when the EV is in the plan, the SoC series must START at the real initial
+    // SoC, never 0. (A 0 in production means the EV was excluded from the plan.)
+    const cfg = {
+      ...base,
+      ev: { ...evBase, evBatteryCapacity_Wh: 75000, evInitialSoc_percent: 78, evTargetSoc_percent: 80 },
+    };
+    const result = highs.solve(buildLP(cfg), GAPS);
+    expect(result.Status).toBe('Optimal');
+    const rows = parseSolution(result, cfg, OPTS);
+    expect(rows[0].ev_soc_percent).toBeGreaterThan(77.5); // starts at ~78, NOT 0
+    expect(rows[7].ev_soc_percent).toBeGreaterThan(79.5); // reaches the 80% target
+    expect(rows.some(r => r.ev_charge > 1)).toBe(true);   // a (small) charge is planned
+  });
+
   it('stays FEASIBLE with a shortfall when the price mask leaves too few slots', () => {
     // Only slots 0,1 are below the 10 c€ ceiling; the rest are masked. Two slots
     // cannot deliver the 18 kWh deficit, so the (soft) target is missed — but the


### PR DESCRIPTION
## Problem

A connected EV at a known SoC was being **dropped from the plan entirely** — the schedule showed no EV charging and the EV SoC chart read **0%** even though the SoC sensor reported the real value.

Root cause: native EV planning only runs when there's a valid charge *window* (`D > 0`). `D` comes from the **"Ready by"** time, and `departureTimeToSlot()` returns `0` for an empty value. With "Ready by" left blank, the window guard at `config-builder.ts:156` skipped EV planning, so no `base.ev` was built → no `ev_soc_*` LP variables → `ev_soc_percent` parsed as 0 everywhere.

## Fix

An unset "Ready by" now defaults to the **end of the known price horizon** (`D = T`): reach target by the last slot we have prices for, charging in the cheapest hours along the way.

```ts
const D = settings.evDepartureTime?.trim()
  ? departureTimeToSlot(settings.evDepartureTime, nowMs, settings.stepSize_m, T)
  : T;
```

The **plug gate is unchanged** — the EV is still only folded into the home-battery co-optimization when actually connected (`evState.pluggedIn`), so the home-battery plan never prepares for an EV draw that won't happen. (An earlier attempt to decouple planning from plug was reverted; co-optimizing home + EV requires the connected check.)

## Verification

- `config-builder` test: empty "Ready by" → EV **is** planned, `evDepartureSlot === horizon`.
- `ev-native-charging` end-to-end solve (HiGHS): a connected EV at 78% with an 80% target → SoC series **starts at 78% (not 0)**, reaches 80%, small charge planned. This directly guards the reported bug.
- typecheck clean, lint clean, **1521 tests pass**.

## Deploy

Bumps `optivolt/config.yaml` to **0.7.33** → new HA add-on image. Needs `ha supervisor restart` to take effect.

After restart, to actually see a charge: **Target SoC must be above current SoC**, and if **Apply price limit** is on with Max price `0`, every hour is masked (turn it off or set a real ceiling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)