### PR TITLE
v0.7.34 fix(ev): EV dropped from every plan when SoC source is Victron MQTT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.34 - 2026-06-14
+
+- **Fix: native EV was dropped from every plan when the SoC source is Victron MQTT.** `getSolverInputs()` builds the solver config *with* the EV (from the live HA SoC/plug read), but the `dataSources.soc === 'mqtt'` path then **rebuilt the config without passing `evState`**, so the rebuilt config silently excluded the EV — the solver ran with `ev: null` every cycle, the schedule planned no EV charging, and the EV SoC chart read 0% even with the car connected at a known SoC. `getSolverInputs()` now returns `evState`, and both config rebuilds in `planner-service` (the MQTT-SoC refresh and the rebalance-reset paths) pass it through. Added a planner regression test that fails if either rebuild drops the EV. This is the real cause of the "EV SoC shows 0%" report; the 0.7.33 "Ready by" default was a separate, valid improvement.
+
 ## 0.7.33 - 2026-06-14
 
 - **Fix: plan EV charging when no "Ready by" deadline is set.** Native EV planning only runs when there is a valid charge window. With "Ready by" left empty, the window collapsed to zero slots and the EV was dropped from the plan entirely — so the schedule showed no EV charging and the EV SoC chart read 0% even with the car connected at a known SoC. An unset "Ready by" now defaults to the **end of the known price horizon** (reach target by the last slot we have prices for, charging in the cheapest hours along the way). The plug gate is unchanged: the EV is still only folded into the home-battery co-optimization when it is actually connected, so the home-battery plan never prepares for an EV draw that won't happen.

--- a/api/services/config-builder.ts
+++ b/api/services/config-builder.ts
@@ -268,7 +268,7 @@ export function applyCalibration(cfg: SolverConfig, cal: CalibrationResult): Sol
   return result;
 }
 
-export async function getSolverInputs(): Promise<{ cfg: SolverConfig; timing: { startMs: number; stepMin: number }; data: Data; settings: Settings }> {
+export async function getSolverInputs(): Promise<{ cfg: SolverConfig; timing: { startMs: number; stepMin: number }; data: Data; settings: Settings; evState?: { pluggedIn: boolean; soc_percent: number } }> {
   const [settings, loadedData] = await Promise.all([loadSettings(), loadData()]);
   const startMs = getQuarterStart(new Date(), settings.stepSize_m);
   const pruned = pruneExpiredPredictionAdjustments(loadedData, startMs);
@@ -318,5 +318,8 @@ export async function getSolverInputs(): Promise<{ cfg: SolverConfig; timing: { 
     }
   }
 
-  return { cfg, timing: { startMs, stepMin: settings.stepSize_m }, data, settings };
+  // evState is returned so callers that REBUILD cfg (e.g. after an MQTT SoC
+  // refresh or a rebalance reset) can pass it back in — otherwise the rebuilt
+  // cfg silently drops the EV (no 4th arg → evState undefined → EV excluded).
+  return { cfg, timing: { startMs, stepMin: settings.stepSize_m }, data, settings, evState };
 }

--- a/api/services/planner-service.ts
+++ b/api/services/planner-service.ts
@@ -201,11 +201,12 @@ export async function computePlan({ updateData = false } = {}): Promise<ComputeP
     }
   }
 
-  let { cfg, timing, data, settings } = await getSolverInputs();
+  let { cfg, timing, data, settings, evState } = await getSolverInputs();
 
   if (settings.dataSources.soc === 'mqtt') {
     data = await refreshMqttSocForPlan(data, settings.shoreOptimizer?.batteryInstance);
-    cfg = buildSolverConfigFromSettings(settings, data, timing.startMs);
+    // Pass evState through — without it the rebuilt cfg drops the EV entirely.
+    cfg = buildSolverConfigFromSettings(settings, data, timing.startMs, evState);
   }
 
   // Pre-solve bookkeeping: if a rebalance cycle just completed, auto-disable
@@ -213,8 +214,8 @@ export async function computePlan({ updateData = false } = {}): Promise<ComputeP
     data = { ...data, rebalanceState: { startMs: null } };
     settings = { ...settings, rebalanceEnabled: false };
     await Promise.all([saveSettings(settings), saveData(data)]);
-    // Rebuild cfg without rebalance constraints
-    cfg = buildSolverConfigFromSettings(settings, applyPredictionAdjustmentsToData(data), timing.startMs);
+    // Rebuild cfg without rebalance constraints (still preserving the EV).
+    cfg = buildSolverConfigFromSettings(settings, applyPredictionAdjustmentsToData(data), timing.startMs, evState);
   }
 
   const lpText = buildLP(cfg);

--- a/optivolt/config.yaml
+++ b/optivolt/config.yaml
@@ -1,6 +1,6 @@
 name: Optivolt
 slug: optivolt
-version: "0.7.33"
+version: "0.7.34"
 description: Plan and control Victron ESS with forecasts & dynamic tariffs!
 url: https://github.com/vervoto1/optivolt
 image: "ghcr.io/vervoto1/{arch}-addon-optivolt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optivolt",
-  "version": "0.7.33",
+  "version": "0.7.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optivolt",
-      "version": "0.7.33",
+      "version": "0.7.34",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optivolt",
-  "version": "0.7.33",
+  "version": "0.7.34",
   "description": "Optivolt is a linear and mixed-integer optimizer for home energy systems.",
   "homepage": "https://github.com/bmesuere/optivolt#readme",
   "bugs": {

--- a/tests/api/services/planner-service.test.js
+++ b/tests/api/services/planner-service.test.js
@@ -6,12 +6,14 @@ vi.mock('../../../api/services/data-store.ts');
 vi.mock('../../../api/services/vrm-refresh.ts');
 vi.mock('../../../api/services/mqtt-service.ts');
 vi.mock('../../../api/services/plan-history-store.ts');
+vi.mock('../../../api/services/ha-client.ts');
 
 import { loadSettings, saveSettings } from '../../../api/services/settings-store.ts';
 import { loadData, saveData } from '../../../api/services/data-store.ts';
 import { refreshSeriesFromVrmAndPersist } from '../../../api/services/vrm-refresh.ts';
 import { readVictronSocPercent, setDynamicEssSchedule } from '../../../api/services/mqtt-service.ts';
 import { savePlanSnapshot } from '../../../api/services/plan-history-store.ts';
+import { fetchHaEntityState } from '../../../api/services/ha-client.ts';
 import { computePlan, planAndMaybeWrite } from '../../../api/services/planner-service.ts';
 import { FeedIn } from '../../../lib/dess-mapper.ts';
 
@@ -303,6 +305,35 @@ describe('computePlan — MQTT SoC refresh', () => {
 
     await expect(computePlan()).rejects.toThrow('Failed to read battery SoC from Victron MQTT');
     expect(savePlanSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('keeps the EV in the plan after the MQTT SoC rebuild (regression: cfg rebuilt without evState)', async () => {
+    // getSolverInputs() builds cfg WITH the EV; the soc=mqtt path then rebuilds
+    // cfg, and previously did so without evState — silently dropping the EV every
+    // cycle (solve logged `ev: null`). The rebuild must now carry evState through.
+    loadSettings.mockResolvedValue({
+      ...baseSettings,
+      dataSources: { ...baseSettings.dataSources, soc: 'mqtt' },
+      shoreOptimizer: { batteryInstance: 512 },
+      evEnabled: true,
+      evSocSensor: 'sensor.ev_soc',
+      evPlugSensor: 'sensor.ev_plug',
+      evMinChargeCurrent_A: 6,
+      evMaxChargeCurrent_A: 16,
+      evChargePhases: 1,
+      evBatteryCapacity_kWh: 60,
+      evChargeEfficiency_percent: 100,
+      evTargetSoc_percent: 80,
+      evDepartureTime: '', // defaults to end of horizon
+    });
+    readVictronSocPercent.mockResolvedValue(50);
+    fetchHaEntityState.mockImplementation(({ entityId }) =>
+      Promise.resolve({ state: entityId === 'sensor.ev_soc' ? '40' : 'connected' }));
+
+    const result = await computePlan();
+
+    expect(result.cfg.ev).toBeDefined();
+    expect(result.cfg.ev.evInitialSoc_percent).toBe(40);
   });
 });
 


### PR DESCRIPTION
## Problem (the real one)

A connected EV at a known SoC was excluded from the plan on **every** solve — logs showed `[calculate] solve { ev: null }`, the schedule had no EV charging, and the EV SoC chart read **0%**. No "Could not read EV state" warning, because the HA SoC/plug read actually succeeded.

Root cause: `getSolverInputs()` builds `cfg` **with** the EV (passing `evState` to `buildSolverConfigFromSettings`). But `planAndMaybeWrite` then **rebuilds** `cfg` when `dataSources.soc === 'mqtt'` (to fold in the live Victron MQTT battery SoC) — and that rebuild call omitted the 4th `evState` argument:

```ts
// before
if (settings.dataSources.soc === 'mqtt') {
  data = await refreshMqttSocForPlan(...);
  cfg = buildSolverConfigFromSettings(settings, data, timing.startMs); // ← drops the EV
}
```

With `evState` undefined, the EV gate fails and `base.ev` is never built → `ev: null`. Since the target system's SoC source **is** Victron MQTT, this fired every cycle. The same omission existed on the rebalance-reset rebuild.

## Fix

`getSolverInputs()` now returns `evState`, and both rebuilds in `planner-service` pass it through:

```ts
let { cfg, timing, data, settings, evState } = await getSolverInputs();
...
cfg = buildSolverConfigFromSettings(settings, data, timing.startMs, evState);
```

## Verification

- New planner regression test: with `soc: 'mqtt'` + native EV (HA SoC/plug mocked), the solved `result.cfg.ev` is defined with the right initial SoC. **Confirmed it fails without the fix** (reverted the line → test red) and passes with it.
- typecheck clean, lint clean, **1522 tests pass**.

## Context

This supersedes the 0.7.33 "Ready by" default as the actual cause of the "EV SoC shows 0%" report. That default is still a valid improvement (unset deadline → charge across the known horizon), just not what was blocking this system.

## Deploy

Bumps `optivolt/config.yaml` to **0.7.34** → new HA add-on image; needs `ha supervisor restart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)