### PR TITLE
EV UI: confine disconnected-car preview to the EV tab + explain opportunistic top-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.39 - 2026-06-16
+
+- **Optimizer overview now reflects only the real plan — the disconnected-car EV preview is confined to the EV tab.** When the car is unplugged, the backend returns an "if plugged in now" EV preview; it was being overlaid on the overview SoC chart (EV-SoC line + EV target line), which made the overview show a charge that isn't actually planned. The overview now draws an EV-SoC line and EV target/departure markers only when the EV is genuinely in the plan (its SoC is in the solved rows); the preview still drives the EV tab.
+- **EV settings: explain the opportunistic top-up bands in the UI.** Added inline help to "Opportunistic level" and "Opportunistic level 2": top-up charges the car above the target SoC, up to the level, using only the cheapest slots in the plan (surplus solar or the lowest-priced grid hours) — and a note that setting the level equal to the target disables top-up. Band 2 is described as a second, lower-priority tier that only fills after band 1 and only when energy is even cheaper. No behaviour change.
+
 ## 0.7.38 - 2026-06-16
 
 - **EV "ready by" is now a time-of-day + Today/Tomorrow picker instead of a date+time picker.** The deadline used to be an *absolute* datetime, which had no business carrying a date for a daily charging routine and silently went stale: once it elapsed, the charge window collapsed to zero (`departureTimeToSlot` → 0) and EV planning switched off entirely — the forecast showed the car flat at its current SoC with no charge plan until the date was manually bumped, so charging stopped the morning after each deadline. It is now stored as a wall-clock time (`"HH:MM"`, empty = no deadline) plus a `today`/`tomorrow` selector, **resolved relative to "now" on every plan and live decision** (both the planner and the actuator share one resolver), so it can't drift into the past and can't point further out than tomorrow. A legacy stored datetime is migrated down to its time-of-day automatically. The "set to end of plan" quick-set button is gone (leaving the time empty is the equivalent "charge by end of horizon").

--- a/app/index.html
+++ b/app/index.html
@@ -1929,6 +1929,7 @@
               <label class="block text-sm">
                 <span class="block text-xs font-medium text-slate-400 dark:text-slate-500 mb-1 tracking-wide">Opportunistic level (%)</span>
                 <input id="ev-opportunistic-level" type="number" min="0" max="100" step="1" class="form-input" data-settings-input />
+                <span class="mt-1 block text-xs text-slate-500 dark:text-slate-400">Charges the car <strong>above</strong> the target SoC, up to this level, using only the cheapest slots in the plan (surplus solar, or the lowest-priced grid hours) — it never tops up during expensive hours, but it <em>can</em> use cheap grid, not just free solar. Set this equal to the target to never charge past it.</span>
               </label>
               <label class="toggle">
                 <input id="ev-opportunistic-type2-enabled" type="checkbox" data-settings-input>
@@ -1938,6 +1939,7 @@
               <label class="block text-sm">
                 <span class="block text-xs font-medium text-slate-400 dark:text-slate-500 mb-1 tracking-wide">Opportunistic level 2 (%)</span>
                 <input id="ev-opportunistic-type2-level" type="number" min="0" max="100" step="1" class="form-input" data-settings-input />
+                <span class="mt-1 block text-xs text-slate-500 dark:text-slate-400">An optional second tier, from the level above up to this one. It is rewarded slightly less, so it fills only after the first band and only when energy is even cheaper — the car reaches the very top (e.g. 100%) only on the cheapest days.</span>
               </label>
 
               <!-- Reactive overrides -->

--- a/app/src/charts/solution-charts.js
+++ b/app/src/charts/solution-charts.js
@@ -222,7 +222,10 @@ export function drawSocChart(canvas, rows, _stepSize_m = 15, evSettings = null, 
     });
   }
 
-  const evTargetPlugin = evSettings
+  // Only annotate the EV target/departure on the overview when the EV is actually
+  // in the plan (real-plan EV SoC present). A disconnected-car preview is confined
+  // to the EV tab, so the overview shows neither the preview SoC line nor its target.
+  const evTargetPlugin = (evSettings && hasEvSoc)
     ? makeEvTargetPlugin(rows, evSettings.departureTime, evSettings.targetSoc_percent)
     : null;
 

--- a/app/src/optimizer-controller.js
+++ b/app/src/optimizer-controller.js
@@ -83,11 +83,13 @@ export function createOptimizerController({ els, services = {} }) {
       renderScheduleTable();
 
       // When the car is disconnected the real plan has no EV; the backend then
-      // returns evPreview — the schedule as it would be if plugged in now. Use it
-      // for the EV charts/panel (display-only; never applied to Victron). The main
-      // SoC chart keeps real battery data and overlays the preview EV-SoC line.
+      // returns evPreview — the schedule as it would be if plugged in now. It is
+      // display-only (never applied to Victron) and is confined to the EV tab. The
+      // optimizer overview reflects only the real plan, so the overview charts are
+      // NOT given the preview: the overview SoC chart shows an EV-SoC line only when
+      // the car is actually in the plan (its EV SoC lives in `rows`).
       const evPreview = result.evPreview ?? null;
-      renderAllCharts(rows, cfgForViz, result.rebalanceWindow ?? null, evSettings, evPreview?.rows ?? null);
+      renderAllCharts(rows, cfgForViz, result.rebalanceWindow ?? null, evSettings);
       deps.updateEvPanel(
         els,
         evPreview?.rows ?? rows,

--- a/optivolt/config.yaml
+++ b/optivolt/config.yaml
@@ -1,6 +1,6 @@
 name: Optivolt
 slug: optivolt
-version: "0.7.38"
+version: "0.7.39"
 description: Plan and control Victron ESS with forecasts & dynamic tariffs!
 url: https://github.com/vervoto1/optivolt
 image: "ghcr.io/vervoto1/{arch}-addon-optivolt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optivolt",
-  "version": "0.7.38",
+  "version": "0.7.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optivolt",
-      "version": "0.7.38",
+      "version": "0.7.39",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optivolt",
-  "version": "0.7.38",
+  "version": "0.7.39",
   "description": "Optivolt is a linear and mixed-integer optimizer for home energy systems.",
   "homepage": "https://github.com/bmesuere/optivolt#readme",
   "bugs": {

--- a/tests/app/optimizer-controller.test.js
+++ b/tests/app/optimizer-controller.test.js
@@ -132,7 +132,7 @@ describe('optimizer controller', () => {
     expect(els.run.classList.contains('loading')).toBe(false);
   });
 
-  it('feeds the EV preview into the EV panel and SoC overlay when the result includes one', async () => {
+  it('feeds the EV preview into the EV panel only, never the overview SoC chart', async () => {
     const { controller, els, rows, services, summary } = setupController();
     const previewRows = [{ timestampMs: 1, ev_soc_percent: 60, soc_percent: 50 }];
     const previewSummary = { evChargeTotal_kWh: 1, evChargeFromGrid_kWh: 1, evChargeFromPv_kWh: 0, evChargeFromBattery_kWh: 0 };
@@ -144,8 +144,9 @@ describe('optimizer controller', () => {
 
     await controller.onRun();
 
-    // Battery SoC keeps the real rows; the EV-SoC overlay uses the preview rows (5th arg).
-    expect(services.drawSocChart).toHaveBeenCalledWith(els.soc, rows, 30, expect.anything(), previewRows);
+    // The overview SoC chart reflects only the real plan — the preview is NOT
+    // overlaid (5th arg stays null); it only goes to the EV tab.
+    expect(services.drawSocChart).toHaveBeenCalledWith(els.soc, rows, 30, expect.anything(), null);
     // EV panel renders the preview schedule + summary and receives the preview object.
     expect(services.updateEvPanel).toHaveBeenCalledWith(els, previewRows, previewSummary, 30, evPreview);
   });


### PR DESCRIPTION
## 1. Overview reflects only the real plan (EV preview confined to EV tab)

When the car is disconnected, the backend returns an "if plugged in now" EV preview. It was being overlaid on the **overview** SoC chart (EV-SoC line + EV target line), so the overview showed a charge that isn't actually planned. The overview now draws the EV-SoC line and target/departure markers **only when the EV is genuinely in the solved plan** (its SoC is in `rows`); the preview still drives the EV tab.

- `optimizer-controller` no longer passes the preview rows to the overview charts.
- `solution-charts` gates the EV target/departure plugin on real-plan EV SoC (`hasEvSoc`).

## 2. Explain the opportunistic top-up settings in the UI

No behaviour change — just inline help on the EV settings tab:

- **Opportunistic level**: charges the car *above* the target SoC, up to this level, using only the cheapest slots in the plan (surplus solar or the lowest-priced grid hours). Set it equal to the target to never charge past it.
- **Opportunistic level 2**: an optional second tier above the first, rewarded slightly less, so it fills only after band 1 and only when energy is even cheaper.

## Tests

Updated the optimizer-controller test to assert the overview never receives the preview. Full suite green (1607), typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
