### PR TITLE
fix(ev): land charging on the target SoC instead of overshooting a full slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.40 - 2026-06-16
+
+- **EV charging now lands on the target SoC instead of overshooting a full slot.** A forced-rate charger (`evMinChargeCurrent_A == evMaxChargeCurrent_A`, e.g. a 16 A-only Tesla) can only move SoC in whole 15-minute slot chunks, so meeting the soft target floor forced a full slot that stepped *past* the target — e.g. planning the car to 82–83% for an 80% target (and over-committing grid energy to that overshoot). Two fixes:
+  - **Planner:** the single slot that crosses the target may now charge *partially* (a `ev_tgt_t` relaxation of the forced-rate minimum, gated to within one slot of the target), so the plan lands on the target. Skipped when the learned acceptance taper is active, which already relaxes the minimum near full. No effect below the target — earlier slots still charge at the full forced rate.
+  - **Actuator:** the live EV controller now switches the charger off the moment live SoC reaches the target, mid-slot, rather than running out the rest of the plan slot. A genuinely opportunistic slot (above target, scheduled only when energy is cheap) is exempt.
+
 ## 0.7.39 - 2026-06-16
 
 - **Optimizer overview now reflects only the real plan — the disconnected-car EV preview is confined to the EV tab.** When the car is unplugged, the backend returns an "if plugged in now" EV preview; it was being overlaid on the overview SoC chart (EV-SoC line + EV target line), which made the overview show a charge that isn't actually planned. The overview now draws an EV-SoC line and EV target/departure markers only when the EV is genuinely in the plan (its SoC is in the solved rows); the preview still drives the EV tab.

--- a/api/services/ev-decision-service.ts
+++ b/api/services/ev-decision-service.ts
@@ -165,6 +165,13 @@ export async function computeEvDecision(
     const planned: EvDecisionMode = row.ev_plan_mode === 'opportunistic'
       ? 'opportunistic'
       : row.ev_plan_mode === 'min_soc' ? 'min_soc' : 'planned';
+    // Switch off the moment the car reaches the target, mid-slot — don't run out the
+    // rest of a 15-min plan slot (a forced-rate charger would overshoot within it).
+    // Only a genuinely opportunistic slot (above target, scheduled when energy is
+    // cheap) may keep charging past the target.
+    if (planned !== 'opportunistic' && liveSoc != null && liveSoc >= targetSoc) {
+      return charge('idle', 0, 0, `Live SoC ${liveSoc}% at/above target ${targetSoc}%`);
+    }
     return charge(planned, row.ev_charge, row.ev_charge_A, 'Following day-ahead plan');
   }
 

--- a/lib/build-lp.ts
+++ b/lib/build-lp.ts
@@ -219,6 +219,10 @@ export function buildLP({
   const evTrans          = (t: number) => `ev_trans_${t}`;
   // EV charge-acceptance taper binary: 1 iff start-of-slot EV SoC >= threshold k.
   const evCvBin          = (k: number, t: number) => `ev_cv_${k}_${t}`;
+  // EV target-landing relaxation binary: may be 1 only when start-of-slot EV SoC is
+  // within one full slot of the target, letting that crossing slot charge partially
+  // so the plan lands ON the target instead of overshooting it (forced-rate chargers).
+  const evTgtBin         = (t: number) => `ev_tgt_${t}`;
 
   // EV derived constants (only used when ev is defined)
   const evActive        = ev != null;
@@ -271,6 +275,28 @@ export function buildLP({
   const evOppActive  = evHasDepConstraint && evOppCapWh  > evTargetWh + 1e-6;
   const evOppActive2 = evOppActive && evOppCap2Wh > evOppCapWh + 1e-6;
   const evContinuous = !!ev?.evContinuous && evActive;
+
+  // Target-landing relaxation. A forced-rate charger (evMin == evMax) can only move
+  // SoC in whole-slot chunks, so meeting the soft target floor forces a full slot
+  // that OVERSHOOTS the target. Let the single slot that crosses the target charge
+  // partially by relaxing its minimum-power floor (ev_tgt_t), so the plan lands on
+  // the target rather than stepping past it. ev_tgt_t may be 1 only when start-of-slot
+  // SoC is within one full slot of the target (constraint below). Cost minimisation
+  // then lands exactly on the target — no overshoot, no spurious above-target SoC.
+  const evOneSlotMaxChargeWh = evMaxPow_W * evChargeWhPerW;
+  const evTgtRelaxActive = evActive && evHasDepConstraint
+    && evMinPow_W > 1e-6
+    && evTargetWh > evInitialWh + 1e-6
+    && evTargetWh < evCapacityWh - 1e-6
+    && evOneSlotMaxChargeWh > 1e-6
+    // Skip when the learned acceptance taper is active: it already relaxes the min
+    // near full, and double-relaxing lets the solve land a slot-start exactly on a
+    // taper SoC threshold (where the taper binary isn't strictly forced). The taper
+    // is off by default, so production charging still gets target-landing.
+    && evCvK === 0;
+  const evTgtThresholdWh = Math.max(0, evTargetWh - evOneSlotMaxChargeWh);
+  const evTgtTerm = (t: number) =>
+    evTgtRelaxActive ? ` + ${toNum(evMinPow_W)} ${evTgtBin(t)}` : '';
 
   // A slot is masked (normal EV charge forced to 0) when it is before the
   // earliest-start window, at/after the departure slot, or — under a price
@@ -584,7 +610,7 @@ export function buildLP({
       // term is additive on a >= constraint, so when ev_on=0 (flow pinned to 0) it
       // only loosens the bound — never infeasible. When charging near full it lets
       // a forced-rate charger draw below its nominal minimum as the BMS tapers.
-      lines.push(` c_ev_min_${t}: ${gridToEv(t)} + ${toNum(eta_inv)} ${pvToEv(t)} + ${toNum(eta_inv)} ${batteryToEv(t)} - ${toNum(evMinPow_W)} ${evOn(t)}${evCvTerms(t)} >= 0`);
+      lines.push(` c_ev_min_${t}: ${gridToEv(t)} + ${toNum(eta_inv)} ${pvToEv(t)} + ${toNum(eta_inv)} ${batteryToEv(t)} - ${toNum(evMinPow_W)} ${evOn(t)}${evCvTerms(t)}${evTgtTerm(t)} >= 0`);
       lines.push(` c_ev_max_${t}: ${gridToEv(t)} + ${toNum(eta_inv)} ${pvToEv(t)} + ${toNum(eta_inv)} ${batteryToEv(t)} - ${toNum(evMaxPow_W)} ${evOn(t)} <= 0`);
       if (evCvK > 0) {
         // Constant-RHS max cap carrying the taper. Unlike c_ev_max (gated by
@@ -602,6 +628,17 @@ export function buildLP({
             lines.push(` c_ev_cv_${k}_${t}: ${evSocVar(t - 1)} - ${toNum(tightM)} ${evCvBin(k, t)} <= ${toNum(evCvThresholdWh[k])}`);
             lines.push(` c_ev_cv_rev_${k}_${t}: ${toNum(evCvThresholdWh[k])} ${evCvBin(k, t)} - ${evSocVar(t - 1)} <= 0`);
           }
+        }
+      }
+      if (evTgtRelaxActive) {
+        // Allow the target-landing relaxation (ev_tgt_t = 1) only when start-of-slot
+        // EV SoC is at/above the threshold (within one full slot of the target).
+        // One-directional: the LP raises ev_tgt_t to relax the min when it wants a
+        // partial top-off slot; it can't raise it early to dodge the forced rate.
+        if (t === 0) {
+          lines.push(` c_ev_tgt_${t}: ${toNum(evTgtThresholdWh)} ${evTgtBin(t)} <= ${toNum(evInitialWh)}`);
+        } else {
+          lines.push(` c_ev_tgt_${t}: ${toNum(evTgtThresholdWh)} ${evTgtBin(t)} - ${evSocVar(t - 1)} <= 0`);
         }
       }
       if (evFloorActive) {
@@ -775,6 +812,12 @@ export function buildLP({
     for (let k = 0; k < evCvK; k++) {
       for (let t = 0; t < T; t++) {
         lines.push(` ${evCvBin(k, t)}`);
+      }
+    }
+    // EV target-landing relaxation binaries
+    if (evTgtRelaxActive) {
+      for (let t = 0; t < T; t++) {
+        lines.push(` ${evTgtBin(t)}`);
       }
     }
     lines.push("");

--- a/optivolt/config.yaml
+++ b/optivolt/config.yaml
@@ -1,6 +1,6 @@
 name: Optivolt
 slug: optivolt
-version: "0.7.39"
+version: "0.7.40"
 description: Plan and control Victron ESS with forecasts & dynamic tariffs!
 url: https://github.com/vervoto1/optivolt
 image: "ghcr.io/vervoto1/{arch}-addon-optivolt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optivolt",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optivolt",
-      "version": "0.7.39",
+      "version": "0.7.40",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optivolt",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "description": "Optivolt is a linear and mixed-integer optimizer for home energy systems.",
   "homepage": "https://github.com/bmesuere/optivolt#readme",
   "bugs": {

--- a/tests/api/services/ev-decision-service.test.js
+++ b/tests/api/services/ev-decision-service.test.js
@@ -141,4 +141,30 @@ describe('computeEvDecision — priority + gating', () => {
     expect(d.plugConnected).toBe(null);
     expect(d.mode).toBe('planned'); // not forced idle by an uncertain plug
   });
+
+  it('stops a planned charge mid-slot once live SoC reaches the target', async () => {
+    // Plan slot still says charge, but the car already hit 80% — switch off rather
+    // than run out the 15-min slot (which a forced-rate charger would overshoot).
+    mockHa({ soc: '80', plug: 'on' });
+    const d = await computeEvDecision(makeSettings(), makePlan({ evCharge: 11040, planMode: 'planned' }), NOW);
+    expect(d.mode).toBe('idle');
+    expect(d.is_charging).toBe(false);
+    expect(d.reason).toMatch(/target/i);
+  });
+
+  it('keeps charging above target on a genuinely opportunistic slot', async () => {
+    // Above the target, but the LP scheduled this slot as opportunistic (cheap
+    // energy) — the target-reached guard must not block it.
+    mockHa({ soc: '82', plug: 'on' });
+    const d = await computeEvDecision(makeSettings(), makePlan({ evCharge: 11040, planMode: 'opportunistic' }), NOW);
+    expect(d.mode).toBe('opportunistic');
+    expect(d.is_charging).toBe(true);
+  });
+
+  it('charges a planned slot normally while live SoC is below target', async () => {
+    mockHa({ soc: '70', plug: 'on' });
+    const d = await computeEvDecision(makeSettings(), makePlan({ evCharge: 11040, planMode: 'planned' }), NOW);
+    expect(d.mode).toBe('planned');
+    expect(d.is_charging).toBe(true);
+  });
 });

--- a/tests/lib/ev-land-on-target.test.js
+++ b/tests/lib/ev-land-on-target.test.js
@@ -1,0 +1,86 @@
+// @ts-nocheck
+/**
+ * Target-landing for a forced-rate EV charger. A 16 A-only charger (evMin == evMax)
+ * can only move SoC in whole 15-min slot chunks, so meeting the soft target floor
+ * used to force a full slot that OVERSHOOTS the target (e.g. land on 83% for an 80%
+ * target). The target-landing relaxation lets the single crossing slot charge
+ * partially, so the plan lands ON the target instead of stepping past it.
+ *
+ * Ascending prices front-load charging into a unique contiguous block (kills MIP
+ * symmetry, keeps the forced-rate solve fast).
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import highsFactory from '../../vendor/highs-build/highs.js';
+import { buildLP } from '../../lib/build-lp.ts';
+import { parseSolution } from '../../lib/parse-solution.ts';
+
+const T = 12;
+const base = {
+  load_W: Array(T).fill(400),
+  pv_W: Array(T).fill(0),
+  importPrice: Array.from({ length: T }, (_, t) => 5 + t), // ascending → charge ASAP
+  exportPrice: Array(T).fill(1),
+  stepSize_m: 15,
+  batteryCapacity_Wh: 20000,
+  minSoc_percent: 10,
+  maxSoc_percent: 100,
+  maxChargePower_W: 4000,
+  maxDischargePower_W: 4000,
+  maxGridImport_W: 30000,
+  maxGridExport_W: 5000,
+  chargeEfficiency_percent: 95,
+  dischargeEfficiency_percent: 95,
+  inverterEfficiency_percent: 95,
+  batteryCost_cent_per_kWh: 1,
+  idleDrain_W: 0,
+  terminalSocValuation: 'zero',
+  initialSoc_percent: 50,
+};
+
+// Forced-rate charger: evMin == evMax == 11040 W. 75 kWh pack ⇒ one full slot adds
+// 11040 × (0.25 h × 0.9) / 75000 ≈ 3.31% — so 80% is NOT reachable on a slot boundary
+// from 72% (72 → 75.31 → 78.62 → would overshoot to ~81.9% without the relaxation).
+const evForced = {
+  evMinChargePower_W: 11040,
+  evMaxChargePower_W: 11040,
+  evBatteryCapacity_Wh: 75000,
+  evInitialSoc_percent: 72,
+  evTargetSoc_percent: 80,
+  evDepartureSlot: T,
+  evChargeEfficiency_percent: 90,
+  evChargePhases: 3,
+};
+
+const OPTS = { startMs: 0, stepMin: 15 };
+const GAPS = { mip_rel_gap: 0.01, mip_abs_gap: 0.5 };
+
+describe('EV target-landing (forced-rate charger)', () => {
+  let highs;
+  beforeAll(async () => { highs = await highsFactory({}); });
+
+  it('lands on the target instead of overshooting a full slot', () => {
+    const cfg = { ...base, ev: { ...evForced } };
+    const result = highs.solve(buildLP(cfg), GAPS);
+    expect(result.Status).toBe('Optimal');
+    const rows = parseSolution(result, cfg, OPTS);
+
+    const finalSoc = rows[rows.length - 1].ev_soc_percent;
+    // Reaches the target...
+    expect(finalSoc).toBeGreaterThanOrEqual(79.5);
+    // ...without overshooting it by (most of) a full ~3.31% slot.
+    expect(finalSoc).toBeLessThanOrEqual(80.6);
+  });
+
+  it('still charges at the full forced rate well below the target', () => {
+    const cfg = { ...base, ev: { ...evForced } };
+    const result = highs.solve(buildLP(cfg), GAPS);
+    const rows = parseSolution(result, cfg, OPTS);
+    // The relaxation only applies within one slot of the target; earlier slots still
+    // charge at the full forced 11 kW.
+    const fullEarly = rows.some((r, i) => {
+      const startSoc = i === 0 ? cfg.ev.evInitialSoc_percent : rows[i - 1].ev_soc_percent;
+      return startSoc < 76 && r.ev_charge > 10000;
+    });
+    expect(fullEarly).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

The EV plan charged **past** the target SoC — e.g. suggesting **82–83%** for an **80%** target. A forced-rate charger (`evMinChargeCurrent_A == evMaxChargeCurrent_A`, a 16 A-only Tesla) can only move SoC in whole 15-minute slot chunks (~3.3%/slot), so to satisfy the 80% target floor the plan does a full slot that overshoots. The "opportunistic" label on that slot is just SoC-band classification — the overshoot persists with opportunistic charging **disabled**, confirming it's quantization, not the opportunistic reward.

## Fix

- **Planner (`build-lp`)**: the single slot that crosses the target may now charge **partially** — an `ev_tgt_t` relaxation of the forced-rate minimum, gated to within one full slot of the target. Cost minimisation then lands the plan exactly on the target. Earlier slots still charge at the full forced rate. Skipped when the learned acceptance taper is active (it already relaxes the minimum near full; double-relaxing would land a slot-start on a taper threshold boundary).
- **Actuator (`ev-decision-service`)**: the live controller switches the charger **off the moment live SoC reaches the target, mid-slot**, instead of running out the rest of the plan slot. A genuinely opportunistic slot (above target, scheduled only when energy is cheap) is exempt.

Together: the forecast lands on the target, and the real car stops at the target mid-slot.

## Tests

- New `tests/lib/ev-land-on-target.test.js`: a forced-rate charger lands on the target (≤ target + 0.6%), not a full-slot overshoot; still charges full rate below target.
- 3 new actuator-guard tests (stops at target; exempts opportunistic; charges normally below target).
- Full suite green (1612), typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
