### PR TITLE
fix(ev): top off onto target in one partial slot, not a sub-rate dribble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.41 - 2026-06-16
+
+- **EV target top-off is now a single partial slot, not a sub-rate dribble.** The 0.7.40 target-landing fix could land on the target by smearing a low-rate charge across several slots near the top (e.g. 1.3 kW, 1.3, 2.3, 1.7) — which misrepresents what the charger does (it runs at the forced rate, then cuts off). A relaxed slot must now *complete* the charge to the target within that one slot (`c_ev_tgt_reach`), so the plan shows full forced-rate slots followed by a single partial top-off slot (the slot-average of "16 A, then cut off at the target"), then idle.
+
 ## 0.7.40 - 2026-06-16
 
 - **EV charging now lands on the target SoC instead of overshooting a full slot.** A forced-rate charger (`evMinChargeCurrent_A == evMaxChargeCurrent_A`, e.g. a 16 A-only Tesla) can only move SoC in whole 15-minute slot chunks, so meeting the soft target floor forced a full slot that stepped *past* the target — e.g. planning the car to 82–83% for an 80% target (and over-committing grid energy to that overshoot). Two fixes:

--- a/lib/build-lp.ts
+++ b/lib/build-lp.ts
@@ -640,6 +640,12 @@ export function buildLP({
         } else {
           lines.push(` c_ev_tgt_${t}: ${toNum(evTgtThresholdWh)} ${evTgtBin(t)} - ${evSocVar(t - 1)} <= 0`);
         }
+        // A relaxed slot must COMPLETE the charge to the target within that one slot
+        // (end-of-slot SoC >= target). This forces a single partial top-off slot —
+        // full forced rate until then — instead of dribbling a sub-rate charge across
+        // several slots, which would misrepresent what the charger actually does
+        // (16 A, then cut off). M = evTargetWh, so it's vacuous when ev_tgt_t = 0.
+        lines.push(` c_ev_tgt_reach_${t}: ${evSocVar(t)} - ${toNum(evTargetWh)} ${evTgtBin(t)} >= 0`);
       }
       if (evFloorActive) {
         // Total charger AC power (normal + floor) is bounded by the charger max,

--- a/optivolt/config.yaml
+++ b/optivolt/config.yaml
@@ -1,6 +1,6 @@
 name: Optivolt
 slug: optivolt
-version: "0.7.40"
+version: "0.7.41"
 description: Plan and control Victron ESS with forecasts & dynamic tariffs!
 url: https://github.com/vervoto1/optivolt
 image: "ghcr.io/vervoto1/{arch}-addon-optivolt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optivolt",
-  "version": "0.7.40",
+  "version": "0.7.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optivolt",
-      "version": "0.7.40",
+      "version": "0.7.41",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optivolt",
-  "version": "0.7.40",
+  "version": "0.7.41",
   "description": "Optivolt is a linear and mixed-integer optimizer for home energy systems.",
   "homepage": "https://github.com/bmesuere/optivolt#readme",
   "bugs": {

--- a/tests/lib/ev-land-on-target.test.js
+++ b/tests/lib/ev-land-on-target.test.js
@@ -71,6 +71,21 @@ describe('EV target-landing (forced-rate charger)', () => {
     expect(finalSoc).toBeLessThanOrEqual(80.6);
   });
 
+  it('lands via full-rate slots + a SINGLE partial top-off (no sub-rate dribble)', () => {
+    const cfg = { ...base, ev: { ...evForced } };
+    const result = highs.solve(buildLP(cfg), GAPS);
+    const rows = parseSolution(result, cfg, OPTS);
+
+    const FULL = evForced.evMaxChargePower_W;
+    // Classify each charging slot: full (≈ forced rate), partial, or off.
+    const partial = rows.filter(r => r.ev_charge > 50 && r.ev_charge < FULL - 50);
+    const full = rows.filter(r => r.ev_charge >= FULL - 50);
+    // The charger runs at its forced rate, then takes at most ONE partial slot to
+    // top off onto the target — never a trickle smeared across several slots.
+    expect(partial.length).toBeLessThanOrEqual(1);
+    expect(full.length).toBeGreaterThanOrEqual(1);
+  });
+
   it('still charges at the full forced rate well below the target', () => {
     const cfg = { ...base, ev: { ...evForced } };
     const result = highs.solve(buildLP(cfg), GAPS);


### PR DESCRIPTION
Follow-up to #30. The target-landing relaxation could reach the target by smearing a low-rate charge across several near-target slots (e.g. 1.3/1.3/2.3/1.7 kW) — which misrepresents the charger (forced rate, then cut off).

Add `c_ev_tgt_reach`: a relaxed slot must COMPLETE the charge to the target within that one slot (end-of-slot SoC >= target). The forced-rate minimum still binds for every other slot, so the plan shows full-rate slots then a SINGLE partial top-off slot (the slot-average of "16 A then cut off"), then idle.

Test asserts at most one partial charging slot. Full suite 1613 green, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)