### PR TITLE
v0.7.42 fix: stop battery drain deferring export into cheaper hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.7.42 - 2026-06-18
+
+- **Draining the battery to grid no longer stalls near low SoC and defers export from an expensive hour into the next cheaper one.** During a high-price evening drain the battery would empty to each 15-minute slot's target, then idle covering only house load for the rest of the slot — a stair-step that pushed the last few kWh out of the high-price hour and into the next, cheaper hour (measured ~€0.8 lost on a 70c→47c step-down, and worse the bigger the price gap). Root cause and fixes:
+  - **Optimizer: dropped the learned low-SoC discharge-power taper.** Adaptive learning was deriving a `dischargePhaseThresholds` ceiling from the `actual / predicted` SoC-change curve. But near a slot's target SoC, DESS stops discharging and just covers load, so "throttled because the target was already reached" was mislearned as "the battery can't discharge fast at low SoC" — and fed back as a hard LP ceiling that made the plan drain too gently and defer export, which produced still more throttled slots (a self-reinforcing loop). The discharge curve is still computed for duration predictions; it no longer constrains the optimizer. The charge/CV taper (a real BMS limit near full) is unchanged.
+  - **Controller: DESS now targets the end SoC of the whole high-price export run, not the per-slot interpolated SoC.** So the inverter dumps at max for the entire expensive window instead of racing each gentle per-slot target and idling. The run stops at any higher future price, so it never front-loads across a price increase it should wait for.
+  - **Planner: added a `preferEarlierDischarge` tiebreak.** Mirrors the existing `preferEarlierCharging`; within an equal-price window the plan now front-loads battery→grid export instead of smearing it arbitrarily across slots. Only breaks ties — a real price difference still dominates.
+- **Battery cell-voltage trend axis pinned to the LiFePO4 2.75–3.75 V window** (was 2.8–3.8 V) so normal cell variation stays visible.
+
 ## 0.7.41 - 2026-06-16
 
 - **EV target top-off is now a single partial slot, not a sub-rate dribble.** The 0.7.40 target-landing fix could land on the target by smearing a low-rate charge across several slots near the top (e.g. 1.3 kW, 1.3, 2.3, 1.7) — which misrepresents what the charger does (it runs at the forced rate, then cuts off). A relaxed slot must now *complete* the charge to the target within that one slot (`c_ev_tgt_reach`), so the plan shows full forced-rate slots followed by a single partial top-off slot (the slot-average of "16 A, then cut off at the target"), then idle.

--- a/api/services/config-builder.ts
+++ b/api/services/config-builder.ts
@@ -235,7 +235,9 @@ export function buildSolverConfigFromSettings(
 export function applyCalibration(cfg: SolverConfig, cal: CalibrationResult): SolverConfig {
   if (cal.confidence < 0.5) return cfg;
 
-  // Generate charge thresholds from calibration curve
+  // Generate charge thresholds from calibration curve. The charge/CV taper is a
+  // real physical limit (a BMS accepts less current as it approaches full), so
+  // modelling it in the LP is correct.
   const chargeThresholds = generateThresholdsFromCurve(
     cal.chargeCurve,
     // v8 ignore next — null path of ?? is untestable with real calibration results
@@ -244,18 +246,23 @@ export function applyCalibration(cfg: SolverConfig, cal: CalibrationResult): Sol
     'charge',
   );
 
-  // Generate discharge thresholds from calibration curve
-  const dischargeThresholds = generateThresholdsFromCurve(
-    cal.dischargeCurve,
-    // v8 ignore next — null path of ?? is untestable with real calibration results
-    cal.dischargeSamples ?? [],
-    cfg.maxDischargePower_W,
-    'discharge',
-  );
+  // NOTE: we deliberately do NOT derive a discharge-power taper from the
+  // calibration curve any more. Unlike charging, the battery has no real
+  // low-SoC discharge limit here (the inverter was measured delivering ~15 kW at
+  // 5% SoC). The discharge curve is `actual / predicted` SoC change per band, and
+  // near a slot's target SoC DESS stops discharging and just covers house load —
+  // so "throttled because the target was already reached" was being mislearned as
+  // "the battery can't discharge fast at low SoC". Feeding that back as a hard LP
+  // discharge-power ceiling made the optimizer plan a too-gentle drain and defer
+  // export from a high-price hour into the next cheaper hour, which in turn
+  // produced more throttled slots — a self-reinforcing loop. The discharge curve
+  // is still computed/persisted by the calibrator for duration predictions; it
+  // just no longer constrains the optimizer. See dischargePhaseThresholds in
+  // build-lp.ts (still supported for a genuine, statically-configured taper).
 
   console.log(
-    `[config-builder] Applying calibration: ${chargeThresholds.length} charge thresholds, ` +
-    `${dischargeThresholds.length} discharge thresholds (confidence=${cal.confidence})`,
+    `[config-builder] Applying calibration: ${chargeThresholds.length} charge thresholds ` +
+    `(discharge taper not applied) (confidence=${cal.confidence})`,
   );
 
   // Map to the SolverConfig threshold format
@@ -265,13 +272,6 @@ export function applyCalibration(cfg: SolverConfig, cal: CalibrationResult): Sol
     result.cvPhaseThresholds = chargeThresholds.map(t => ({
       soc_percent: t.soc_percent,
       maxChargePower_W: t.power_W,
-    }));
-  }
-
-  if (dischargeThresholds.length > 0) {
-    result.dischargePhaseThresholds = dischargeThresholds.map(t => ({
-      soc_percent: t.soc_percent,
-      maxDischargePower_W: t.power_W,
     }));
   }
 

--- a/app/src/ess-tab.js
+++ b/app/src/ess-tab.js
@@ -233,7 +233,7 @@ function renderHistory(state, history) {
     if (!view) return;
 
     // Cell voltage trends — one thin line per cell, legend hidden. Pin the axis
-    // to the LiFePO4 operating window (~2.8–3.8 V) so normal cell variation is
+    // to the LiFePO4 operating window (~2.75–3.75 V) so normal cell variation is
     // visible instead of being flattened against a 0–4 V auto-range.
     const cells = battery.cells ?? [];
     const cellEntries = cells.map((cell, idx) => ({
@@ -241,7 +241,7 @@ function renderHistory(state, history) {
       color: cellColor(idx, cells.length),
       points: pointsFor(history, cell.entity),
     }));
-    const cellsDrawn = renderLineChart(view.trendCanvas, cellEntries, { yTitle: "V", yMin: 2.8, yMax: 3.8, showLegend: false });
+    const cellsDrawn = renderLineChart(view.trendCanvas, cellEntries, { yTitle: "V", yMin: 2.75, yMax: 3.75, showLegend: false });
     if (!cellsDrawn) setChartMessage(view.trendCanvas, "No trend data");
 
     // Temperature trends — legend shown, y pinned to the 20–80 °C operating band.

--- a/lib/build-lp.ts
+++ b/lib/build-lp.ts
@@ -137,6 +137,7 @@ export function buildLP({
     rebalanceStartPerSlot: 1e-6, // escalating per-window penalty on start_balance_k: breaks symmetry between equivalent rebalance windows
     avoidGridRoundTrip: 5e-7, // prefer battery→load over grid→load when battery is already discharging (must exceed HiGHS dual_feasibility_tolerance of 1e-7)
     preferEarlierCharging: 5e-7, // per-slot increasing penalty on g2b to prefer continuous charging from start of price block
+    preferEarlierDischarge: 5e-7, // per-slot increasing penalty on battery→grid to front-load export within an equal-price block (must exceed HiGHS dual_feasibility_tolerance of 1e-7)
     allowCurtailAtNegativePrice: 1e-8, // permit PV curtailment when import/export prices make PV economically harmful
     avoidCurtail: 1e-4, // otherwise prefer using/storing/exporting PV over curtailment
   }
@@ -370,7 +371,7 @@ export function buildLP({
     const gridToLoadCoeff = importCoeff_cents + TIEBREAK.avoidGridRoundTrip; // import cost + tiny nudge to prefer battery→load when prices are equal
     const gridToBatteryCoeff = importCoeff_cents + batteryCost_cents + TIEBREAK.gridToBattery + t * TIEBREAK.preferEarlierCharging; // import cost + battery cost + prefer DC PV charging + slight preference for earlier charging
     const pvToGridCoeff = -acExportCoeff_cents + TIEBREAK.avoidExport; // export revenue (post-inverter) + slight penalty to prefer using PV locally
-    const batteryToGridCoeff = -acExportCoeff_cents + batteryCost_cents; // export revenue (post-inverter) + battery cost
+    const batteryToGridCoeff = -acExportCoeff_cents + batteryCost_cents + t * TIEBREAK.preferEarlierDischarge; // export revenue (post-inverter) + battery cost + slight preference for earlier export (symmetry-break for equal-price drain windows)
     const batteryToLoadCoeff = batteryCost_cents; // battery cost
     const pvToBatteryCoeff = batteryCost_cents + TIEBREAK.pvToBattery; // battery cost + tiny routing tiebreak
     const socShortfallCoeff = softMinSocPenalty_cents_per_Wh; // penalty for being below minSoc

--- a/lib/dess-mapper.ts
+++ b/lib/dess-mapper.ts
@@ -399,15 +399,13 @@ export function mapRowsToDessV2(rows: PlanRow[], cfg: SolverConfig, options: Des
     // Expected PV/load for PV surplus check
     const pvSurplus = row.pv > row.load + row.ev_charge + FLOW_EPSILON_W;
 
-    // Precompute flow totals for saturation checks. Caps:
-    //   maxGridImport_W / maxGridExport_W are AC (utility connection limits).
-    //   maxChargePower_W / maxDischargePower_W are DC (battery limits).
+    // Precompute flow totals for the grid-charge saturation check. Caps:
+    //   maxGridImport_W is AC (utility connection limit).
+    //   maxChargePower_W is DC (battery limit).
     // PlanRow flows: g2* are AC; pv2b is DC; pv2g/pv2l/b2l/b2g/b2ev/pv2ev are AC after parseSolution conversion.
     const eta_inv_v2 = (cfg.inverterEfficiency_percent ?? DEFAULT_INVERTER_EFFICIENCY_PERCENT) / 100;
     const gridImport = row.g2l + row.g2b + (row.g2ev ?? 0);
-    const gridExport = row.b2g + row.pv2g;
     const chargePower_DC = row.pv2b + eta_inv_v2 * row.g2b;
-    const dischargePower_DC = eta_inv_v2 > 0 ? (row.b2g + row.b2l + (row.b2ev ?? 0)) / eta_inv_v2 : 0;
 
     // O(1) tipping-point lookup for this slot's segment
     const seg = getSegmentForIndex(segments, t);
@@ -444,9 +442,24 @@ export function mapRowsToDessV2(rows: PlanRow[], cfg: SolverConfig, options: Des
       // Export price is high enough to dump battery to grid
       strategy = Strategy.proGrid;
       restrictions = Restrictions.gridToBattery; // allow battery→grid
-      if (gridExport >= cfg.maxGridExport_W - FLOW_EPSILON_W || dischargePower_DC >= cfg.maxDischargePower_W - FLOW_EPSILON_W) {
-        socTarget_percent = Math.max(socTarget_percent - 5, cfg.minSoc_percent + 1);
+      // Target the END SoC of the contiguous battery-export run that starts here,
+      // rather than this slot's interpolated SoC. The LP's per-slot SoC trajectory
+      // can be gentle; DESS then races each per-slot target at max power, reaches
+      // it within the slot, and idles covering only house load for the remainder —
+      // leaving export on the table during a high-price window and deferring it to
+      // a later, cheaper slot. Pulling the target to the run's end SoC tells DESS
+      // to dump at max now. We extend the run only while it keeps draining
+      // (b2g > 0) AND the export price never rises above this slot's, so we never
+      // front-load across a price increase we'd rather wait for. SoC falls
+      // monotonically during a drain, so the run-end SoC is its minimum and the
+      // target only ever moves down.
+      let runEnd = t;
+      for (let j = t + 1; j < rows.length; j++) {
+        if (rows[j].b2g <= FLOW_EPSILON_W) break;        // run stopped draining
+        if (rows[j].ec > exportPrice + 1e-6) break;      // higher price ahead — wait for it
+        runEnd = j;
       }
+      socTarget_percent = rows[runEnd].soc_percent;
     } else if (feedinAllowed && pvSurplus && exportPrice >= pvExportTp) {
       // PV surplus goes to grid (battery likely full)
       // Only applies when we actually expect PV to exceed load

--- a/optivolt/config.yaml
+++ b/optivolt/config.yaml
@@ -1,6 +1,6 @@
 name: Optivolt
 slug: optivolt
-version: "0.7.41"
+version: "0.7.42"
 description: Plan and control Victron ESS with forecasts & dynamic tariffs!
 url: https://github.com/vervoto1/optivolt
 image: "ghcr.io/vervoto1/{arch}-addon-optivolt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optivolt",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optivolt",
-      "version": "0.7.41",
+      "version": "0.7.42",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optivolt",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "description": "Optivolt is a linear and mixed-integer optimizer for home energy systems.",
   "homepage": "https://github.com/bmesuere/optivolt#readme",
   "bugs": {

--- a/tests/api/services/config-builder.test.js
+++ b/tests/api/services/config-builder.test.js
@@ -340,19 +340,20 @@ describe('applyCalibration', () => {
     }
   });
 
-  it('populates dischargePhaseThresholds when discharge curve has reductions', () => {
+  it('does NOT derive a discharge taper from the calibration curve', () => {
+    // Even with a strong low-SoC reduction in the discharge curve, we no longer
+    // feed it into the LP: the battery has no real low-SoC discharge limit, and
+    // the curve mostly reflects DESS throttling near a reached target SoC.
+    // Constraining the optimizer with it makes it defer export from a high-price
+    // hour into a cheaper one (a self-reinforcing loop). The charge taper is
+    // unaffected.
     const cal = makeCal();
-    // Set a segment of the discharge curve to show significant reduction
-    // Bands 0-12 are segment 0
-    for (let i = 0; i < 13; i++) cal.dischargeCurve[i] = 0.6;
+    for (let i = 0; i < 13; i++) cal.dischargeCurve[i] = 0.6;  // bands 0-12 = discharge segment 0
+    for (let i = 78; i < 91; i++) cal.chargeCurve[i] = 0.7;    // bands 78-90 = charge segment 6
     const result = applyCalibration(baseCfg, cal);
-    expect(result.dischargePhaseThresholds).toBeDefined();
-    expect(result.dischargePhaseThresholds.length).toBeGreaterThan(0);
-    for (const t of result.dischargePhaseThresholds) {
-      expect(t).toHaveProperty('soc_percent');
-      expect(t).toHaveProperty('maxDischargePower_W');
-      expect(t.maxDischargePower_W).toBeLessThan(baseCfg.maxDischargePower_W);
-    }
+    expect(result.dischargePhaseThresholds).toBeUndefined();
+    expect(result.cvPhaseThresholds).toBeDefined();
+    expect(result.cvPhaseThresholds.length).toBeGreaterThan(0);
   });
 
   it('does not set thresholds when all curve values are >= 0.95', () => {
@@ -732,11 +733,11 @@ describe('getSolverInputs — adaptive learning calibration', () => {
     // Efficiencies should NOT be modified
     expect(cfg.chargeEfficiency_percent).toBe(mockSettings.chargeEfficiency_percent);
     expect(cfg.dischargeEfficiency_percent).toBe(mockSettings.dischargeEfficiency_percent);
-    // With curve values < 0.95, thresholds should be generated
+    // With curve values < 0.95, the charge taper is generated; the discharge
+    // taper is intentionally NOT fed into the optimizer.
     expect(cfg.cvPhaseThresholds).toBeDefined();
     expect(cfg.cvPhaseThresholds.length).toBeGreaterThan(0);
-    expect(cfg.dischargePhaseThresholds).toBeDefined();
-    expect(cfg.dischargePhaseThresholds.length).toBeGreaterThan(0);
+    expect(cfg.dischargePhaseThresholds).toBeUndefined();
   });
 
   it('skips calibration when mode is suggest', async () => {

--- a/tests/app/ess-tab.test.js
+++ b/tests/app/ess-tab.test.js
@@ -76,7 +76,7 @@ describe('initEssTab — rendering', () => {
     expect(document.getElementById('ess-empty').classList.contains('hidden')).toBe(true);
   });
 
-  it('pins the cell-voltage trend axis to the LiFePO4 range (2.8–3.8 V)', async () => {
+  it('pins the cell-voltage trend axis to the LiFePO4 range (2.75–3.75 V)', async () => {
     getEssState.mockResolvedValue({
       batteries: [battery('B0')],
       system: null,
@@ -89,7 +89,7 @@ describe('initEssTab — rendering', () => {
 
     const cellTrendCall = renderLineChart.mock.calls.find(([, , opts]) => opts && opts.yTitle === 'V');
     expect(cellTrendCall).toBeDefined();
-    expect(cellTrendCall[2]).toMatchObject({ yMin: 2.8, yMax: 3.8, showLegend: false });
+    expect(cellTrendCall[2]).toMatchObject({ yMin: 2.75, yMax: 3.75, showLegend: false });
   });
 
   it('pins the temperature trend axis to the 20–80 °C band', async () => {

--- a/tests/lib/build-lp.test.js
+++ b/tests/lib/build-lp.test.js
@@ -112,6 +112,21 @@ describe('buildLP', () => {
     // (if the tiebreak were absent, gridToLoad would have coeff 0 and be omitted)
     expect(lp).toMatch(/\+ 0\.0000005\d* grid_to_load_0/);
   });
+
+  it('battery_to_grid coefficient escalates with t (preferEarlierDischarge tiebreak)', () => {
+    // With exportPrice=0 and batteryCost=0 the battery→grid coefficient is purely
+    // t * 5e-7, so it grows with the slot index — biasing the solver to export
+    // earlier within an equal-price drain window. t=0 has coeff 0 (omitted from
+    // the objective); t=1 and t=2 carry the escalating tiebreak.
+    const lp = buildLP({
+      ...mockData,
+      importPrice: Array(T).fill(0),
+      exportPrice: Array(T).fill(0),
+      batteryCost_cent_per_kWh: 0,
+    });
+    expect(lp).toMatch(/\+ 0\.0000005\d* battery_to_grid_1\b/);
+    expect(lp).toMatch(/\+ 0\.000001\d* battery_to_grid_2\b/);
+  });
 });
 
 describe('buildLP — Victron executable battery/PV behavior', () => {
@@ -119,6 +134,30 @@ describe('buildLP — Victron executable battery/PV behavior', () => {
 
   beforeAll(async () => {
     highs = await highsFactory({});
+  });
+
+  it('front-loads battery export within an equal, profitable price window (preferEarlierDischarge)', () => {
+    // No load/PV, flat profitable export price, ~1 slot worth of energy, terminal
+    // SoC unvalued. Draining slot 0 vs slot 1 earns identical revenue, so the
+    // preferEarlierDischarge tiebreak must break the tie toward the earlier slot
+    // instead of leaving the discharge to land in an arbitrary (e.g. later) slot.
+    const cfg = {
+      load_W: [0, 0],
+      pv_W: [0, 0],
+      importPrice: [30, 30],
+      exportPrice: [30, 30],
+      batteryCapacity_Wh: 10000,
+      initialSoc_percent: 10, // 1000 Wh available
+      minSoc_percent: 0,
+      maxDischargePower_W: 4000,
+      idleDrain_W: 0,
+      batteryCost_cent_per_kWh: 0,
+      terminalSocValuation: 'zero',
+    };
+    const result = highs.solve(buildLP(cfg), { mip_rel_gap: 0, mip_abs_gap: 0 });
+    const rows = parseSolution(result, cfg, { startMs: 0, stepMin: 15 });
+    expect(rows[0].b2g).toBeGreaterThan(rows[1].b2g);
+    expect(rows[1].b2g).toBeLessThan(1); // essentially all export happened in slot 0
   });
 
   it('emits PV curtailment and battery direction constraints for each slot', () => {

--- a/tests/lib/dess-mapper.test.js
+++ b/tests/lib/dess-mapper.test.js
@@ -572,31 +572,44 @@ describe('mapRowsToDessV2', () => {
     expect(perSlot[1].restrictions).toBe(Restrictions.gridToBattery);
   });
 
-  it('applies -5% SoC boost when exporting and grid export is saturated', () => {
+  it('targets the END SoC of a contiguous high-price export run', () => {
+    // Slots 0..2 all export (b2g>0) at a non-rising price while SoC falls
+    // 30→20→10. Every slot should target the run's END SoC (10) so DESS dumps at
+    // max immediately instead of stair-stepping down the per-slot trajectory.
     const rows = [
-      makeRow({ b2g: 100, ec: 20, ic: 100, soc_percent: 50 }),
-      makeRow({ ic: 100, ec: 25, soc_percent: 50, b2g: 4000, pv2g: 1000 }), // b2g+pv2g = 5000 = maxGridExport
+      makeRow({ b2g: 4000, ec: 25, ic: 100, soc_percent: 30 }),
+      makeRow({ b2g: 4000, ec: 25, ic: 100, soc_percent: 20 }),
+      makeRow({ b2g: 4000, ec: 22, ic: 100, soc_percent: 10 }),
     ];
-    const { perSlot } = mapRowsToDessV2(rows, { ...cfg, maxGridExport_W: 5000 });
-    expect(perSlot[1].socTarget_percent).toBe(45); // 50 - 5
+    const { perSlot } = mapRowsToDessV2(rows, cfg);
+    expect(perSlot[0].strategy).toBe(Strategy.proGrid);
+    expect(perSlot[0].socTarget_percent).toBe(10);
+    expect(perSlot[1].socTarget_percent).toBe(10);
+    expect(perSlot[2].socTarget_percent).toBe(10);
   });
 
-  it('does NOT boost SoC when exporting but grid export is not saturated', () => {
+  it('a lone export slot keeps its own planned SoC', () => {
     const rows = [
       makeRow({ b2g: 100, ec: 20, ic: 100, soc_percent: 50 }),
-      makeRow({ ic: 100, ec: 25, soc_percent: 50, b2g: 500, pv2g: 0 }), // 500 < 5000
+      makeRow({ ic: 100, ec: 25, soc_percent: 50, b2g: 500 }), // last slot, run = {itself}
     ];
-    const { perSlot } = mapRowsToDessV2(rows, { ...cfg, maxGridExport_W: 5000 });
-    expect(perSlot[1].socTarget_percent).toBe(50); // no boost
+    const { perSlot } = mapRowsToDessV2(rows, cfg);
+    expect(perSlot[1].strategy).toBe(Strategy.proGrid);
+    expect(perSlot[1].socTarget_percent).toBe(50);
   });
 
-  it('floors SoC boost at minSoc_percent + 1', () => {
+  it('does not front-load the export run across a higher future price', () => {
+    // Slot 1 has a HIGHER export price than slot 0, so slot 0 must NOT be pulled
+    // down to slot 1's SoC — that energy is worth more sold in slot 1. Slot 0
+    // keeps its own end SoC (30); slot 1 keeps its own (20).
     const rows = [
-      makeRow({ b2g: 100, ec: 20, ic: 100, soc_percent: 13 }),
-      makeRow({ ic: 100, ec: 25, soc_percent: 13, b2g: 4000, pv2g: 1000 }), // saturated
+      makeRow({ b2g: 4000, ec: 25, ic: 100, soc_percent: 30 }),
+      makeRow({ b2g: 4000, ec: 40, ic: 100, soc_percent: 20 }),
     ];
-    const { perSlot } = mapRowsToDessV2(rows, { ...cfg, minSoc_percent: 10, maxGridExport_W: 5000 });
-    expect(perSlot[1].socTarget_percent).toBe(11); // floored at 10+1
+    const { perSlot } = mapRowsToDessV2(rows, cfg);
+    expect(perSlot[0].strategy).toBe(Strategy.proGrid);
+    expect(perSlot[0].socTarget_percent).toBe(30);
+    expect(perSlot[1].socTarget_percent).toBe(20);
   });
 
   it('defaults to selfConsumption when no tipping points match', () => {
@@ -883,41 +896,41 @@ describe('mapRowsToDessV2', () => {
 
   // v0.7.23 regression: dess-mapper's AC→DC saturation checks defaulted
   // η_inv to 100% when cfg.inverterEfficiency_percent was omitted, while
-  // buildLP / parseSolution default to 95%. A slot at the DC discharge
-  // cap (4000 W DC = 3800 W AC at η=0.95) was therefore mis-classified as
-  // unconstrained — the -5% socTarget boost never fired, and the DESS
-  // tipping-point helpers over-counted high-price grid usage. The shared
+  // buildLP / parseSolution default to 95%, so the DESS tipping-point
+  // helpers over-counted high-price grid usage. (The export-branch socTarget
+  // boost that originally tripped this was removed when the discharge taper /
+  // run-terminal targeting landed; the same η-default still governs
+  // findHighestGridUsageCost, so the guard moved there.) The shared
   // DEFAULT_INVERTER_EFFICIENCY_PERCENT constant in build-lp.ts pins all
   // three modules to the same default; this test fails on `?? 100` and
   // passes on `?? DEFAULT_INVERTER_EFFICIENCY_PERCENT`.
   describe('inverter efficiency default (saturation check)', () => {
-    it('detects DC discharge saturation when inverterEfficiency_percent is omitted', () => {
-      // Row 0 establishes batteryExportTp = 20 via b2g flow.
-      // Row 1 exports at ec=25 (>= 20 → proGrid branch). b2g=3800 W AC,
-      // pv2g=0, so gridExport = 3800 < maxGridExport_W=5000 — the grid
-      // saturation gate is OPEN. The only path that can pull socTarget
-      // down is the DC discharge cap: with η=0.95, b2g/η = 4000 W DC ≥
-      // maxDischargePower_W (4000) - epsilon → saturated → socTarget
-      // drops to 45. With the legacy η=1.0 default the conversion stays
-      // at 3800 W < cap, no boost fires, socTarget stays at 50.
+    it('pins η default in the gridBatteryTp DC-saturation check', () => {
+      // Slot 1 is a grid-to-load slot whose battery discharge sits exactly at the
+      // DC cap under the correct η=95 default (3800 / 0.95 = 4000 W DC). It must
+      // be treated as SATURATED and excluded from gridBatteryTp; otherwise its
+      // ic=100 lifts the tipping point and (mis)classifies slot 2 as proBattery
+      // instead of exporting. With the legacy η=100 default (3800 < 4000) the
+      // slot leaks in and slot 2 flips to proBattery.
       const rows = [
-        makeRow({ b2g: 100, ec: 20, ic: 100, soc_percent: 50 }),
-        makeRow({ ic: 100, ec: 25, soc_percent: 50, b2g: 3800 }),
+        makeRow({ b2g: 100, ec: 20, ic: 5, soc_percent: 50 }),               // batteryExportTp = 20
+        makeRow({ g2l: 1000, b2l: 3800, ic: 100, ec: 5, soc_percent: 50 }),  // DC-saturated under η=95
+        makeRow({ ic: 50, ec: 25, soc_percent: 50 }),                        // test slot
       ];
       // cfg deliberately omits inverterEfficiency_percent.
       const { perSlot } = mapRowsToDessV2(rows, cfg);
-      expect(perSlot[1].strategy).toBe(Strategy.proGrid);
-      expect(perSlot[1].socTarget_percent).toBe(45);
+      expect(perSlot[2].strategy).toBe(Strategy.proGrid);
     });
 
     it('matches the explicit η=95 path when the field is omitted', () => {
       const rows = [
-        makeRow({ b2g: 100, ec: 20, ic: 100, soc_percent: 50 }),
-        makeRow({ ic: 100, ec: 25, soc_percent: 50, b2g: 3800 }),
+        makeRow({ b2g: 100, ec: 20, ic: 5, soc_percent: 50 }),
+        makeRow({ g2l: 1000, b2l: 3800, ic: 100, ec: 5, soc_percent: 50 }),
+        makeRow({ ic: 50, ec: 25, soc_percent: 50 }),
       ];
-      const omitted = mapRowsToDessV2(rows, cfg).perSlot[1];
-      const explicit = mapRowsToDessV2(rows, { ...cfg, inverterEfficiency_percent: 95 }).perSlot[1];
-      expect(omitted.socTarget_percent).toBe(explicit.socTarget_percent);
+      const omitted = mapRowsToDessV2(rows, cfg).perSlot[2];
+      const explicit = mapRowsToDessV2(rows, { ...cfg, inverterEfficiency_percent: 95 }).perSlot[2];
+      expect(omitted.strategy).toBe(explicit.strategy);
     });
   });
 });


### PR DESCRIPTION
## Problem

During a high-price evening drain, the battery emptied to grid in a stair-step: it raced down to each 15-minute slot's target SoC at max power, hit it within seconds, then **idled covering only house load** for the rest of the slot. That pushed the last few kWh out of the expensive hour and into the next, cheaper hour.

Observed live (2026-06-18): a ~16-minute stall at 10–11% SoC across the 22:00 boundary deferred ~3.5 kWh from a 70 c/kWh window into a 47 c/kWh window — **~€0.8 lost**, and worse the bigger the price gap. It recurs every time the battery drains through low SoC during a price step-down.

Confirmed via Venus MQTT this was **not** a feed-in block (`MaxFeedInPower=-1`, `OvervoltageFeedIn=1`, every drain slot `proGrid` + battery→grid allowed) and **not** the base power cap (`maxDischargePower_W=18000`; inverter measured at 15 kW at 5% SoC).

## Root cause

The optimizer under-modelled discharge *near low SoC*, and the controller followed the gentle trajectory literally:

- Adaptive learning derived a low-SoC discharge-power ceiling (`dischargePhaseThresholds`) from the `actual/predicted` SoC-change curve. But near a slot's target SoC, DESS stops discharging and only covers load — so "throttled because the target was reached" got mislearned as "the battery can't discharge fast at low SoC", fed back as a hard LP ceiling, which made the plan drain more gently and produce *more* throttled slots. A self-reinforcing loop.
- The DESS mapper wrote each slot's interpolated SoC as the target, so the real 15 kW inverter raced each gentle target and idled.

## Fixes

1. **Optimizer — drop the learned low-SoC discharge taper** (`config-builder.ts`). The discharge curve is still computed for duration predictions; it no longer constrains the LP. The charge/CV taper (a real BMS limit near full) is unchanged.
2. **Controller — target the end SoC of the whole high-price export run** (`dess-mapper.ts`), so DESS dumps at max for the entire expensive window. The run stops at any higher future price, so it never front-loads across a price increase it should wait for.
3. **Planner — `preferEarlierDischarge` tiebreak** (`build-lp.ts`), mirroring `preferEarlierCharging`: front-loads battery→grid export within an equal-price window. Only breaks ties; a real price difference still dominates.
4. **UI** — cell-voltage trend axis pinned to the LiFePO4 2.75–3.75 V window (was 2.8–3.8 V). Pre-existing working-tree change, included here.

## Testing

- Full suite **1615 passing** (added: front-loading solve test + escalating-coefficient string test in `build-lp`; rewrote the obsolete `-5%`-boost and discharge-taper tests for the new behavior; repointed the v0.7.23 η-default regression guard to `findHighestGridUsageCost`).
- `npm run typecheck` clean, `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)