### PR TITLE
EV equal-price front-load + Ready-by UI fix, undici security bump, hermetic tests

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -2215,7 +2215,7 @@
           <label class="block text-sm">
             <span class="block text-xs font-medium text-slate-400 dark:text-slate-500 mb-1 tracking-wide">Ready by</span>
             <div class="flex mt-1">
-              <select id="ev-departure-day" class="form-input !mt-0 !rounded-r-none !border-r-0 shrink-0" data-settings-input>
+              <select id="ev-departure-day" class="form-input !mt-0 !rounded-r-none !border-r-0 shrink-0 !w-auto" data-settings-input>
                 <option value="today">Today</option>
                 <option value="tomorrow" selected>Tomorrow</option>
               </select>

--- a/lib/build-lp.ts
+++ b/lib/build-lp.ts
@@ -138,6 +138,7 @@ export function buildLP({
     avoidGridRoundTrip: 5e-7, // prefer battery→load over grid→load when battery is already discharging (must exceed HiGHS dual_feasibility_tolerance of 1e-7)
     preferEarlierCharging: 5e-7, // per-slot increasing penalty on g2b to prefer continuous charging from start of price block
     preferEarlierDischarge: 5e-7, // per-slot increasing penalty on battery→grid to front-load export within an equal-price block (must exceed HiGHS dual_feasibility_tolerance of 1e-7)
+    preferEarlierEvCharging: 5e-7, // per-slot increasing penalty on the EV charge flows to front-load EV charging within an equal-price window (mirrors preferEarlierCharging; the binary ev_on penalty alone is too small to survive the production MIP gap)
     allowCurtailAtNegativePrice: 1e-8, // permit PV curtailment when import/export prices make PV economically harmful
     avoidCurtail: 1e-4, // otherwise prefer using/storing/exporting PV over curtailment
   }
@@ -391,12 +392,22 @@ export function buildLP({
     objTerms.push(` + ${toNum(pvCurtailCoeff)} ${pvCurtail(t)}`);
     /* v8 ignore end */
     if (evActive) {
+      // Per-slot escalating tiebreak added equally to every EV charge flow so it
+      // front-loads charging within an equal-price window WITHOUT disturbing the
+      // grid/pv/battery routing preferences (those are constant offsets, preserved
+      // because the same t-term is added to all three). The binary ev_on penalty
+      // below is too small to survive the production MIP gap; this rides on the
+      // continuous flow variables, which the simplex resolves to dual-feasibility
+      // precision — so it actually biases placement earlier.
+      const evEarlier = t * TIEBREAK.preferEarlierEvCharging;
       /* v8 ignore next — v8 statement counter artifact inside covered if-block */
-      const gridToEvCoeff = importCoeff_cents + TIEBREAK.preferPvForEv;
+      const gridToEvCoeff = importCoeff_cents + TIEBREAK.preferPvForEv + evEarlier;
+      const pvToEvCoeff = TIEBREAK.preferPvForEv + TIEBREAK.pvLoadOverEv + evEarlier;
+      const batteryToEvCoeff = batteryCost_cents + evEarlier;
       // v8 ignore next — loop body push (covered by tests that exercise evActive)
       objTerms.push(` + ${toNum(gridToEvCoeff)} ${gridToEv(t)}`);
-      objTerms.push(` + ${toNum(TIEBREAK.preferPvForEv + TIEBREAK.pvLoadOverEv)} ${pvToEv(t)}`);
-      if (batteryCost_cents !== 0) objTerms.push(` + ${toNum(batteryCost_cents)} ${batteryToEv(t)}`);
+      objTerms.push(` + ${toNum(pvToEvCoeff)} ${pvToEv(t)}`);
+      if (batteryToEvCoeff !== 0) objTerms.push(` + ${toNum(batteryToEvCoeff)} ${batteryToEv(t)}`);
       // Symmetry-breaking: escalating penalty prefers earlier charging when slots are cost-equivalent.
       objTerms.push(` + ${toNum(TIEBREAK.evOnPerSlot * (t + 1))} ${evOn(t)}`);
       if (evFloorActive) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5199,10 +5199,11 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
       }

--- a/tests/lib/build-lp.test.js
+++ b/tests/lib/build-lp.test.js
@@ -127,6 +127,31 @@ describe('buildLP', () => {
     expect(lp).toMatch(/\+ 0\.0000005\d* battery_to_grid_1\b/);
     expect(lp).toMatch(/\+ 0\.000001\d* battery_to_grid_2\b/);
   });
+
+  it('grid_to_ev coefficient escalates with t (preferEarlierEvCharging tiebreak)', () => {
+    // With importPrice=0 the grid→ev coefficient is preferPvForEv (1e-6) plus the
+    // escalating t * 5e-7 earlier-charging tiebreak, so it grows with the slot
+    // index — biasing the solver to charge the EV earlier within an equal-price
+    // window. t=1 → 1e-6 + 5e-7 = 1.5e-6; t=2 → 1e-6 + 1e-6 = 2e-6.
+    const lp = buildLP({
+      ...mockData,
+      importPrice: Array(T).fill(0),
+      exportPrice: Array(T).fill(0),
+      batteryCost_cent_per_kWh: 0,
+      ev: {
+        evMinChargePower_W: 11040,
+        evMaxChargePower_W: 11040,
+        evBatteryCapacity_Wh: 75000,
+        evInitialSoc_percent: 50,
+        evTargetSoc_percent: 80,
+        evDepartureSlot: T,
+        evChargeEfficiency_percent: 90,
+        evChargePhases: 3,
+      },
+    });
+    expect(lp).toMatch(/\+ 0\.0000015\d* grid_to_ev_1\b/);
+    expect(lp).toMatch(/\+ 0\.000002\d* grid_to_ev_2\b/);
+  });
 });
 
 describe('buildLP — Victron executable battery/PV behavior', () => {
@@ -158,6 +183,54 @@ describe('buildLP — Victron executable battery/PV behavior', () => {
     const rows = parseSolution(result, cfg, { startMs: 0, stepMin: 15 });
     expect(rows[0].b2g).toBeGreaterThan(rows[1].b2g);
     expect(rows[1].b2g).toBeLessThan(1); // essentially all export happened in slot 0
+  });
+
+  it('front-loads EV charging within an equal-price window (preferEarlierEvCharging)', () => {
+    // FLAT equal price across the whole horizon, so which slots the EV charges in
+    // is a pure symmetry (every slot costs the same). A 16 A-only charger needs
+    // ~3 slots (72% → 80% on a 75 kWh pack). The preferEarlierEvCharging tiebreak
+    // must pack them into the FIRST slots; without it the optimum is a tie and the
+    // solver can leave charging in arbitrary (e.g. later) slots — the reported bug.
+    const T2 = 8;
+    const cfg = {
+      load_W: Array(T2).fill(400),
+      pv_W: Array(T2).fill(0),
+      importPrice: Array(T2).fill(12),   // flat — no price reason to prefer any slot
+      exportPrice: Array(T2).fill(1),
+      stepSize_m: 15,
+      batteryCapacity_Wh: 20000,
+      minSoc_percent: 10,
+      maxSoc_percent: 100,
+      maxChargePower_W: 4000,
+      maxDischargePower_W: 4000,
+      maxGridImport_W: 30000,
+      maxGridExport_W: 5000,
+      chargeEfficiency_percent: 95,
+      dischargeEfficiency_percent: 95,
+      inverterEfficiency_percent: 95,
+      batteryCost_cent_per_kWh: 1,
+      idleDrain_W: 0,
+      terminalSocValuation: 'zero',
+      initialSoc_percent: 50,
+      ev: {
+        evMinChargePower_W: 11040,
+        evMaxChargePower_W: 11040,
+        evBatteryCapacity_Wh: 75000,
+        evInitialSoc_percent: 72,
+        evTargetSoc_percent: 80,
+        evDepartureSlot: T2,
+        evChargeEfficiency_percent: 90,
+        evChargePhases: 3,
+      },
+    };
+    const result = highs.solve(buildLP(cfg), { mip_rel_gap: 0, mip_abs_gap: 0 });
+    const rows = parseSolution(result, cfg, { startMs: 0, stepMin: 15 });
+    const onSlots = rows.map((r, t) => (r.ev_charge_A > 0.01 ? t : -1)).filter((t) => t >= 0);
+    // Charging is packed into the earliest slots (contiguous from slot 0), so the
+    // first slot charges and the back half of the window stays idle.
+    expect(onSlots[0]).toBe(0);
+    expect(onSlots[onSlots.length - 1]).toBeLessThan(T2 - 1);
+    expect(rows[T2 - 1].ev_charge_A).toBeLessThan(0.01);
   });
 
   it('emits PV curtailment and battery direction constraints for each slot', () => {

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,16 @@
+import { beforeEach } from 'vitest';
+
+// When the suite runs inside Home Assistant OS (e.g. the add-on container or an
+// SSH session under /config), the platform exports SUPERVISOR_TOKEN into the
+// environment. resolveHaHttpConfig/resolveHaWsConfig treat that token as a
+// signal to route through the supervisor proxy, which flips the HA client into
+// add-on mode and breaks tests that assert standalone behaviour (missing creds
+// -> error/null, configured haUrl is used, etc.). CI has no SUPERVISOR_TOKEN,
+// so this only bites locally. Clear it before every test so the suite is
+// hermetic by default; tests that exercise the supervisor path set the token
+// explicitly inside the test body.
+delete process.env.SUPERVISOR_TOKEN;
+
+beforeEach(() => {
+  delete process.env.SUPERVISOR_TOKEN;
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    setupFiles: ['./tests/setup.js'],
     env: {
       TZ: 'Europe/Amsterdam',
     },


### PR DESCRIPTION
## Summary

Bundles the EV equal-price front-load feature with a UI fix, a security bump, and a test-hermeticity fix.

- **feat(lp): front-load EV charging within equal-price windows** (`49ca19a`) — mirrors the existing `preferEarlierCharging` tiebreak for the EV plan so equal-priced slots fill earliest-first instead of smearing arbitrarily. Real price differences still dominate; tie-only.
- **fix: EV "Ready by" layout** (`186d571`) — the Today/Tomorrow `<select>` inherited `width:100%` from `.form-input` and had `shrink-0`, so it consumed the whole flex row and squashed the time input to near-zero. Added `!w-auto` so the select sizes to content and the time field fills the rest.
- **chore(sec): bump undici 7.25.0 → 7.28.0** (`857bb94`) — clears the open Dependabot advisories (high + moderate). undici is a dev-only transitive dep via `jsdom`; production runtime was never exposed. `npm audit` now reports 0 vulnerabilities. Lockfile-only.
- **test: hermetic against ambient `SUPERVISOR_TOKEN`** (`40d774a`) — running the suite inside HAOS leaks `SUPERVISOR_TOKEN`, which flips `resolveHaHttpConfig` into supervisor-proxy mode and broke 11 standalone-mode assertions locally (CI was unaffected). A global vitest setup now clears it before each test, matching the per-file `delete` idiom already used elsewhere. Supervisor-path tests set the token explicitly inside the test body, so they're unaffected.

## Test plan

- `npm run lint` ✓
- `npm run typecheck` ✓
- `npm run test:run` ✓ — 1617 passing / 96 files (was 1606 passing / 11 failing locally before the hermetic fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
