### PR TITLE
chore: run CI on Node 24; ignore .codex and *.log

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - name: Use Node.js 22
+    - name: Use Node.js 24
       uses: actions/setup-node@v6
       with:
-        node-version: 22
+        node-version: 24
         cache: 'npm'
 
     - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ coverage/
 data/plan-history.json
 .superpowers/
 docs/superpowers/
+.codex
+*.log


### PR DESCRIPTION
## Summary
- **CI → Node 24.** Bump the Tests workflow (`actions/setup-node`) from Node 22 to Node 24. `engines` already permits `^22.13.0 || >=24`, and the GitHub runner was already forcing some actions onto Node 24.
- **.gitignore.** Ignore the local `.codex` file and `*.log` runtime logs so they no longer show as untracked.

## Notes / scope
- The **add-on runtime stays on Node 22** — it's pinned by the Home Assistant base image (`home-assistant/*-base:3.22`, Alpine 3.22 → Node 22) and the `node:22-alpine` deps stage. Moving production to Node 24 would need an Alpine 3.23+ HA base and a version bump/rebuild; deliberately out of scope here.
- The Node 20 deprecation warning seen in CI comes from `codecov/codecov-action@v5` bundling `actions/github-script` — transitive and not fixable from this repo.

No app version bump (CI config + .gitignore only; no runtime source change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)