### PR TITLE
feat(ev): read the target SoC from a Home Assistant entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
   This closes a silent failure mode. With the two numbers drifting apart, a car limit *below* OptiVolt's target meant the car stopped at its own limit while OptiVolt kept seeing "SoC below target": it went on booking cheap slots for a charge that could never happen, held the charger energized, and kept battery→grid discharge suppressed for a session that was already over.
 
-  Reads are best-effort and never block a plan — no entity configured, HA unreachable, or a non-numeric state (`unavailable`/`unknown`) falls back to the static `evTargetSoc_percent`, which stays the setting of record. Values are clamped to 0–100.
+  Reads are best-effort and never block a plan — no entity configured, HA unreachable, a non-numeric state (`unavailable`/`unknown`), or a non-positive one falls back to the static `evTargetSoc_percent`, which stays the setting of record. Values above 100 are clamped. A `0` state is treated as unusable rather than as a 0% target: nobody sets a car to charge to 0%, but an unsynced `input_number`, a template sensor evaluating to 0, or a mistyped entity id all report it, and taking it literally would silently plan no charge at all and drop the minimum-SoC floor. When the live value overrides the setting, the plan logs which entity it came from.
 
 ## 0.7.45 - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.7.46 - 2026-08-06
+
+- **EV target SoC can now be read from the car instead of retyped in OptiVolt.** New optional `evTargetSocEntity` setting ("Target SoC entity ID" in the EV settings card) points at the car's own charge-limit entity — e.g. `number.tesla_charge_limit`. While it is set and readable, its value replaces the static Target SoC everywhere the target is used: the LP target, the min-SoC floor clamp, the opportunistic band bases, the EV preview solve, and the live mid-slot "target reached, stop charging" cutoff. Changing the limit in the car's app is now enough — no second edit in OptiVolt.
+
+  This closes a silent failure mode. With the two numbers drifting apart, a car limit *below* OptiVolt's target meant the car stopped at its own limit while OptiVolt kept seeing "SoC below target": it went on booking cheap slots for a charge that could never happen, held the charger energized, and kept battery→grid discharge suppressed for a session that was already over.
+
+  Reads are best-effort and never block a plan — no entity configured, HA unreachable, or a non-numeric state (`unavailable`/`unknown`) falls back to the static `evTargetSoc_percent`, which stays the setting of record. Values are clamped to 0–100.
+
 ## 0.7.45 - 2026-07-30
 
 Ported the correctness fixes from upstream `bmesuere/optivolt` that our fork was missing. The upstream EV availability-window rework was deliberately left out — it replaces the EV model this fork already has.

--- a/api/defaults/default-settings.json
+++ b/api/defaults/default-settings.json
@@ -187,6 +187,7 @@
   "evDepartureTime": "",
   "evDepartureDay": "tomorrow",
   "evTargetSoc_percent": 80,
+  "evTargetSocEntity": "",
   "evChargeEfficiency_percent": 90,
   "evStartTime": "",
   "evApplyPriceLimit": false,

--- a/api/services/config-builder.ts
+++ b/api/services/config-builder.ts
@@ -379,7 +379,16 @@ export async function getSolverInputs(): Promise<{ cfg: SolverConfig; timing: { 
         && plugEntity.state !== 'off';
       if (Number.isFinite(soc_percent)) {
         evState = { pluggedIn, soc_percent };
-        if (liveTarget != null) evState.targetSoc_percent = liveTarget;
+        if (liveTarget != null) {
+          evState.targetSoc_percent = liveTarget;
+          // Every failure path here is deliberately silent, so the success path
+          // has to say something — otherwise a plan built to a target the user
+          // never typed is indistinguishable from one built to the setting.
+          // Once per plan, not per control tick, and only when they disagree.
+          if (liveTarget !== settings.evTargetSoc_percent) {
+            console.log(`[ev] target SoC ${liveTarget}% read from ${settings.evTargetSocEntity} (overrides the ${settings.evTargetSoc_percent}% setting)`);
+          }
+        }
       }
     } catch (err) {
       console.warn('Could not read EV state from HA:', err instanceof Error ? err.message : String(err));

--- a/api/services/config-builder.ts
+++ b/api/services/config-builder.ts
@@ -8,9 +8,21 @@ import { extractWindow, getQuarterStart, getSeriesEndMs } from '../../lib/time-s
 import { fetchHaEntityState } from './ha-client.ts';
 import { resolveEvMode } from './ev-mode.ts';
 import { resolveDepartureMs } from './ev-departure.ts';
+import { fetchEvTargetSoc } from './ev-target-soc.ts';
 import { evChargeWattsPerAmp } from '../../lib/build-lp.ts';
 import type { SolverConfig, EvConfig } from '../../lib/types.ts';
 import type { Settings, Data, CalibrationResult, EvCalibrationResult } from '../types.ts';
+
+/**
+ * Live EV readings that seed the plan. `targetSoc_percent` is present only when
+ * an `evTargetSocEntity` was configured and readable; otherwise the static
+ * `evTargetSoc_percent` setting is used.
+ */
+export interface EvLiveState {
+  pluggedIn: boolean;
+  soc_percent: number;
+  targetSoc_percent?: number;
+}
 
 function departureTimeToSlot(
   departureMs: number,
@@ -57,7 +69,7 @@ export function buildSolverConfigFromSettings(
   settings: Settings,
   data: Data,
   nowMs = getQuarterStart(new Date(), settings.stepSize_m),
-  evState?: { pluggedIn: boolean; soc_percent: number },
+  evState?: EvLiveState,
 ): SolverConfig {
   const loadEndMs   = getSeriesEndMs(data.load);
   const pvEndMs     = getSeriesEndMs(data.pv);
@@ -148,6 +160,10 @@ export function buildSolverConfigFromSettings(
     const minPow_W = settings.evMinChargeCurrent_A * wattsPerAmp;
     const maxPow_W = settings.evMaxChargeCurrent_A * wattsPerAmp;
     const capacityWh = settings.evBatteryCapacity_kWh * 1000;
+    // Live target (the car's own charge limit, when an entity is configured and
+    // readable) wins over the static setting — planning to a target the car
+    // refuses to reach books cheap slots for a charge that never happens.
+    const targetSoc_percent = evState.targetSoc_percent ?? settings.evTargetSoc_percent;
 
     // "Ready by" deadline. When the user has not set one, default to the end of
     // the known horizon — i.e. reach target by the last slot we have prices for,
@@ -177,7 +193,7 @@ export function buildSolverConfigFromSettings(
       // Capacity-only clamp. The OLD achievable-charge clamp lowered the target
       // before the LP saw it, so the (now soft) target read as "met" while the
       // car sat below the user's requested SoC. Soft target carries feasibility.
-      const requestedTargetWh = Math.min((settings.evTargetSoc_percent / 100) * capacityWh, capacityWh);
+      const requestedTargetWh = Math.min((targetSoc_percent / 100) * capacityWh, capacityWh);
 
       const ev: EvConfig = {
         evMinChargePower_W: Math.min(minPow_W, maxPow_W),
@@ -202,16 +218,16 @@ export function buildSolverConfigFromSettings(
       // above the initial SoC — otherwise it is already satisfied.
       /* v8 ignore next — the `?? 0` arm is unreachable: Number.isFinite() short-circuits the && for any nullish evMinSoc_percent, so the nullish-coalesce never falls back */
       if (Number.isFinite(settings.evMinSoc_percent) && (settings.evMinSoc_percent ?? 0) > 0) {
-        ev.evMinSocFloor_percent = Math.min(settings.evMinSoc_percent!, settings.evTargetSoc_percent);
+        ev.evMinSocFloor_percent = Math.min(settings.evMinSoc_percent!, targetSoc_percent);
       }
 
       // Opportunistic top-up bands (caps above target, clamped to 100%).
       if (settings.evOpportunisticEnabled && Number.isFinite(settings.evOpportunisticLevel_percent)) {
-        const cap = Math.min(100, Math.max(settings.evTargetSoc_percent, settings.evOpportunisticLevel_percent!));
-        if (cap > settings.evTargetSoc_percent) ev.evOpportunisticCap_percent = cap;
+        const cap = Math.min(100, Math.max(targetSoc_percent, settings.evOpportunisticLevel_percent!));
+        if (cap > targetSoc_percent) ev.evOpportunisticCap_percent = cap;
       }
       if (settings.evOpportunisticType2Enabled && Number.isFinite(settings.evOpportunisticType2Level_percent)) {
-        const base1 = ev.evOpportunisticCap_percent ?? settings.evTargetSoc_percent;
+        const base1 = ev.evOpportunisticCap_percent ?? targetSoc_percent;
         const cap2 = Math.min(100, Math.max(base1, settings.evOpportunisticType2Level_percent!));
         if (cap2 > base1) ev.evOpportunisticType2Cap_percent = cap2;
       }
@@ -331,7 +347,7 @@ export function applyEvCalibration(cfg: SolverConfig, evCal: EvCalibrationResult
   };
 }
 
-export async function getSolverInputs(): Promise<{ cfg: SolverConfig; timing: { startMs: number; stepMin: number }; data: Data; settings: Settings; evState?: { pluggedIn: boolean; soc_percent: number } }> {
+export async function getSolverInputs(): Promise<{ cfg: SolverConfig; timing: { startMs: number; stepMin: number }; data: Data; settings: Settings; evState?: EvLiveState }> {
   const [settings, loadedData] = await Promise.all([loadSettings(), loadData()]);
   const startMs = getQuarterStart(new Date(), settings.stepSize_m);
   const pruned = pruneExpiredPredictionAdjustments(loadedData, startMs);
@@ -346,12 +362,15 @@ export async function getSolverInputs(): Promise<{ cfg: SolverConfig; timing: { 
 
   if (shouldSaveData) await saveData(data);
 
-  let evState: { pluggedIn: boolean; soc_percent: number } | undefined;
+  let evState: EvLiveState | undefined;
   if (resolveEvMode(settings) === 'native' && settings.evSocSensor && settings.evPlugSensor) {
     try {
-      const [socEntity, plugEntity] = await Promise.all([
+      // fetchEvTargetSoc never rejects (null when unset/unreadable), so a missing
+      // target entity can't take the SoC/plug read down with it.
+      const [socEntity, plugEntity, liveTarget] = await Promise.all([
         fetchHaEntityState({ haUrl: settings.haUrl, haToken: settings.haToken, entityId: settings.evSocSensor }),
         fetchHaEntityState({ haUrl: settings.haUrl, haToken: settings.haToken, entityId: settings.evPlugSensor }),
+        fetchEvTargetSoc(settings),
       ]);
       const soc_percent = parseFloat(socEntity.state);
       const pluggedIn = plugEntity.state !== 'disconnected'
@@ -360,6 +379,7 @@ export async function getSolverInputs(): Promise<{ cfg: SolverConfig; timing: { 
         && plugEntity.state !== 'off';
       if (Number.isFinite(soc_percent)) {
         evState = { pluggedIn, soc_percent };
+        if (liveTarget != null) evState.targetSoc_percent = liveTarget;
       }
     } catch (err) {
       console.warn('Could not read EV state from HA:', err instanceof Error ? err.message : String(err));

--- a/api/services/ev-decision-service.ts
+++ b/api/services/ev-decision-service.ts
@@ -4,6 +4,7 @@ import { evChargeWattsPerAmp } from '../../lib/build-lp.ts';
 import { fetchHaEntityState } from './ha-client.ts';
 import { resolveEvMode } from './ev-mode.ts';
 import { resolveDepartureMs } from './ev-departure.ts';
+import { fetchEvTargetSoc } from './ev-target-soc.ts';
 
 /**
  * Effective live EV mode. Reactive overrides (low_soc/low_price/min_soc/keep_on)
@@ -87,7 +88,9 @@ export async function computeEvDecision(
   const minA = settings.evMinChargeCurrent_A;
   const maxW = maxA * wattsPerAmp;
   const minW = minA * wattsPerAmp;
-  const targetSoc = settings.evTargetSoc_percent;
+  // Baseline target; replaced below by the live entity value when one is
+  // configured and readable (see the HA reads).
+  let targetSoc = settings.evTargetSoc_percent;
   // Resolve the wall-clock "ready by" time-of-day + today/tomorrow selector to an
   // absolute instant relative to now (null when unset). Surfaced as ISO metadata
   // and used by the keep-on window check below.
@@ -121,6 +124,11 @@ export async function computeEvDecision(
         plugConnected = interpretPlug(p.state);
       } catch { plugConnected = null; }
     }
+    // Target SoC from the car's own charge limit, when configured. Keeping this
+    // in step with the planner matters for the mid-slot cutoff below: a stale
+    // higher target keeps the charger running past the limit the car enforces.
+    const liveTarget = await fetchEvTargetSoc(settings);
+    if (liveTarget != null) targetSoc = liveTarget;
   }
 
   const base = {

--- a/api/services/ev-decision-service.ts
+++ b/api/services/ev-decision-service.ts
@@ -4,7 +4,7 @@ import { evChargeWattsPerAmp } from '../../lib/build-lp.ts';
 import { fetchHaEntityState } from './ha-client.ts';
 import { resolveEvMode } from './ev-mode.ts';
 import { resolveDepartureMs } from './ev-departure.ts';
-import { fetchEvTargetSoc } from './ev-target-soc.ts';
+import { resolveEvTargetSoc } from './ev-target-soc.ts';
 
 /**
  * Effective live EV mode. Reactive overrides (low_soc/low_price/min_soc/keep_on)
@@ -107,28 +107,34 @@ export async function computeEvDecision(
     ? (lastPlan.rows.find(r => r.ev_target_met != null)?.ev_target_met ?? null)
     : null;
 
-  // Live HA reads (best-effort).
+  // Live HA reads (best-effort). Concurrent, not sequential: this runs on the
+  // actuator's control tick, every REST read carries its own 10s timeout, and
+  // three of them back-to-back against a stalled HA would burn half the default
+  // 60s interval — long enough that the `ticking` guard drops the ticks queued
+  // behind it. One round trip's worth of wall-clock instead of three.
   let liveSoc: number | null = null;
   let plugConnected: boolean | null = null;
   if (settings.haUrl || process.env.SUPERVISOR_TOKEN) {
-    if (settings.evSocSensor) {
-      try {
-        const s = await fetchHaEntityState({ haUrl: settings.haUrl, haToken: settings.haToken, entityId: settings.evSocSensor });
-        const v = parseFloat(s.state);
-        if (Number.isFinite(v)) liveSoc = v;
-      } catch { /* HA unavailable → fall back to plan */ }
-    }
-    if (settings.evPlugSensor) {
-      try {
-        const p = await fetchHaEntityState({ haUrl: settings.haUrl, haToken: settings.haToken, entityId: settings.evPlugSensor });
-        plugConnected = interpretPlug(p.state);
-      } catch { plugConnected = null; }
-    }
-    // Target SoC from the car's own charge limit, when configured. Keeping this
-    // in step with the planner matters for the mid-slot cutoff below: a stale
-    // higher target keeps the charger running past the limit the car enforces.
-    const liveTarget = await fetchEvTargetSoc(settings);
-    if (liveTarget != null) targetSoc = liveTarget;
+    const [soc, plug, liveTarget] = await Promise.all([
+      settings.evSocSensor
+        ? fetchHaEntityState({ haUrl: settings.haUrl, haToken: settings.haToken, entityId: settings.evSocSensor })
+            .then(s => { const v = parseFloat(s.state); return Number.isFinite(v) ? v : null; })
+            .catch(() => null) /* HA unavailable → fall back to plan */
+        : Promise.resolve(null),
+      settings.evPlugSensor
+        ? fetchHaEntityState({ haUrl: settings.haUrl, haToken: settings.haToken, entityId: settings.evPlugSensor })
+            .then(p => interpretPlug(p.state))
+            .catch(() => null)
+        : Promise.resolve(null),
+      // Target SoC from the car's own charge limit, when configured. Keeping this
+      // in step with the planner matters for the mid-slot cutoff below: a stale
+      // higher target keeps the charger running past the limit the car enforces.
+      // Resolves to the static setting on every failure path.
+      resolveEvTargetSoc(settings),
+    ]);
+    liveSoc = soc;
+    plugConnected = plug;
+    targetSoc = liveTarget;
   }
 
   const base = {

--- a/api/services/ev-target-soc.ts
+++ b/api/services/ev-target-soc.ts
@@ -1,0 +1,54 @@
+/**
+ * ev-target-soc.ts
+ *
+ * Resolves the EV target SoC. `evTargetSoc_percent` is the baseline, but when
+ * `evTargetSocEntity` names a Home Assistant entity — typically the car's own
+ * charge limit (`number.tesla_charge_limit`) — its numeric state wins.
+ *
+ * That keeps a single owner for the target. Without it the two drift apart, and
+ * a car limit *below* OptiVolt's target is the expensive failure: the car stops
+ * at its own limit while the planner keeps booking cheap slots for a charge that
+ * never happens, keeps the charger energized, and keeps battery→grid discharge
+ * suppressed for a session that is already finished.
+ *
+ * Every read is best-effort: no entity configured, no HA connection, or a
+ * non-numeric state (`unavailable`, `unknown`) falls back to the static setting.
+ */
+
+import type { Settings } from '../types.ts';
+import { fetchHaEntityState } from './ha-client.ts';
+
+/** Parse an HA state string into a 0–100 target SoC, or null when unusable. */
+export function parseTargetSocState(state: string | undefined): number | null {
+  const value = parseFloat(String(state ?? ''));
+  if (!Number.isFinite(value)) return null;
+  return Math.max(0, Math.min(100, value));
+}
+
+/**
+ * Live target SoC from the configured HA entity, or null when no entity is set,
+ * HA is not configured/reachable, or the state is not a number.
+ */
+export async function fetchEvTargetSoc(settings: Settings): Promise<number | null> {
+  const entityId = (settings.evTargetSocEntity ?? '').trim();
+  if (!entityId) return null;
+  // Same guard the decision layer uses: standalone needs haUrl, add-on mode goes
+  // through the supervisor proxy.
+  if (!settings.haUrl && !process.env.SUPERVISOR_TOKEN) return null;
+
+  try {
+    const entity = await fetchHaEntityState({
+      haUrl: settings.haUrl,
+      haToken: settings.haToken,
+      entityId,
+    });
+    return parseTargetSocState(entity.state);
+  } catch {
+    return null; // HA unavailable → caller falls back to the setting
+  }
+}
+
+/** Effective target SoC: the live entity value when readable, else the setting. */
+export async function resolveEvTargetSoc(settings: Settings): Promise<number> {
+  return (await fetchEvTargetSoc(settings)) ?? settings.evTargetSoc_percent;
+}

--- a/api/services/ev-target-soc.ts
+++ b/api/services/ev-target-soc.ts
@@ -11,18 +11,29 @@
  * never happens, keeps the charger energized, and keeps battery→grid discharge
  * suppressed for a session that is already finished.
  *
- * Every read is best-effort: no entity configured, no HA connection, or a
- * non-numeric state (`unavailable`, `unknown`) falls back to the static setting.
+ * Every read is best-effort: no entity configured, no HA connection, a
+ * non-numeric state (`unavailable`, `unknown`), or a non-positive one falls back
+ * to the static setting.
  */
 
 import type { Settings } from '../types.ts';
 import { fetchHaEntityState } from './ha-client.ts';
 
-/** Parse an HA state string into a 0–100 target SoC, or null when unusable. */
+/**
+ * Parse an HA state string into a 0–100 target SoC, or null when unusable.
+ *
+ * Zero and negative states are unusable, not a 0% target. Nobody sets a car to
+ * "charge to 0%", but an `input_number` helper before its first sync, a template
+ * sensor that evaluates to 0, or an entity id pointing at the wrong thing all
+ * report it — and taking it literally is silent and expensive: the LP plans no
+ * EV charge at all, `evMinSocFloor_percent` clamps to 0 so the minimum-SoC floor
+ * stops protecting the car, and the decision layer's `liveSoc >= targetSoc`
+ * cutoff idles every planned slot. Fall back to the setting instead.
+ */
 export function parseTargetSocState(state: string | undefined): number | null {
   const value = parseFloat(String(state ?? ''));
-  if (!Number.isFinite(value)) return null;
-  return Math.max(0, Math.min(100, value));
+  if (!Number.isFinite(value) || value <= 0) return null;
+  return Math.min(100, value);
 }
 
 /**

--- a/api/services/planner-service.ts
+++ b/api/services/planner-service.ts
@@ -353,7 +353,7 @@ export async function computePlan({ updateData = false } = {}): Promise<ComputeP
         settings,
         applyPredictionAdjustmentsToData(data),
         timing.startMs,
-        { pluggedIn: true, soc_percent: liveSoc },
+        { pluggedIn: true, soc_percent: liveSoc, targetSoc_percent: evState.targetSoc_percent },
       );
       if (previewCfg.ev) {
         const previewResult = highs.solve(buildLP(previewCfg), solveOptions);

--- a/api/services/settings-schema.ts
+++ b/api/services/settings-schema.ts
@@ -317,6 +317,10 @@ function normalizeEvNativeSettings(s: Settings): void {
   // Earliest-start window (ISO local datetime or empty)
   s.evStartTime = typeof s.evStartTime === 'string' ? s.evStartTime : '';
 
+  // Target-SoC source: optional HA entity (e.g. the car's own charge limit)
+  // that overrides evTargetSoc_percent while it is readable. Empty = static.
+  s.evTargetSocEntity = String(s.evTargetSocEntity ?? '').trim();
+
   // Price limit
   s.evApplyPriceLimit = s.evApplyPriceLimit === true;
   s.evMaxPrice_cents_per_kWh = optNumber(s.evMaxPrice_cents_per_kWh); // may be negative

--- a/api/types.ts
+++ b/api/types.ts
@@ -69,6 +69,13 @@ export interface Settings {
   /** Which day the "ready by" time falls on, resolved relative to now. */
   evDepartureDay?: 'today' | 'tomorrow';
   evTargetSoc_percent: number;
+  /**
+   * Optional HA entity holding the target SoC — typically the car's own charge
+   * limit (`number.tesla_charge_limit`). When set and readable its state wins
+   * over `evTargetSoc_percent`, so changing the limit in the car's app steers
+   * both the plan and the live charge decision.
+   */
+  evTargetSocEntity?: string;
   evChargeEfficiency_percent: number;
 
   // ---- Feature-parity planning controls (port of EV Smart Charging) ----

--- a/app/index.html
+++ b/app/index.html
@@ -1892,6 +1892,12 @@
                   class="form-input font-mono text-xs" data-no-autosolve data-settings-input />
                 <span id="ev-plug-value" class="mt-1 block text-xs text-slate-500 dark:text-slate-400"></span>
               </label>
+              <label class="block text-sm">Target SoC entity ID (optional)
+                <input id="ev-target-soc-entity" type="text" placeholder="number.tesla_charge_limit"
+                  class="form-input font-mono text-xs" data-no-autosolve data-settings-input />
+                <span id="ev-target-soc-entity-value" class="mt-1 block text-xs text-slate-500 dark:text-slate-400"></span>
+                <span class="mt-1 block text-xs text-slate-500 dark:text-slate-400">The car's own charge limit. When set and readable it overrides the Target SoC field on the EV tab, so the limit you pick in the car app is what gets planned.</span>
+              </label>
             </div>
           </section>
 

--- a/app/src/ev-settings.js
+++ b/app/src/ev-settings.js
@@ -12,6 +12,7 @@ function sensorEntries(els) {
   return [
     { input: els.evSocSensor, indicator: els.evSocValue, afterUpdate: () => updateEvSocQuickSet(els) },
     { input: els.evPlugSensor, indicator: els.evPlugValue },
+    { input: els.evTargetSocEntity, indicator: els.evTargetSocEntityValue },
     { input: els.evChargerSwitchEntity, indicator: els.evChargerSwitchValue },
     { input: els.evChargerCurrentEntity, indicator: els.evChargerCurrentValue },
   ];

--- a/app/src/ev-tab.js
+++ b/app/src/ev-tab.js
@@ -1,7 +1,7 @@
 import { SOLUTION_COLORS, toRGBA, drawEvPowerChart, drawEvSocChartTab } from "./charts.js";
 import { formatKWh, updateStackedBarContainer } from "./state.js";
 import { fetchEvStatus, fetchEvOverride, setEvOverride } from "./api/api.js";
-import { resolveDepartureMs } from "./utils.js";
+import { resolveDepartureMs, effectiveTargetSoc } from "./utils.js";
 
 // Live decision badge styling per effective mode (overrides + plan).
 const DECISION_BADGE = {
@@ -129,7 +129,7 @@ export function updateEvPanel(els, rows, summary, stepSize_m = 15, preview = nul
   }
 
   const evSettings = {
-    targetSoc_percent: parseFloat(els.evTargetSoc?.value) || null,
+    targetSoc_percent: effectiveTargetSoc(els.evTargetSocEntityValue?.dataset.haState, els.evTargetSoc?.value),
     departureTime: resolveDepartureMs(els.evDepartureTime?.value, els.evDepartureDay?.value),
   };
 

--- a/app/src/optimizer-controller.js
+++ b/app/src/optimizer-controller.js
@@ -5,7 +5,7 @@ import {
   drawLoadPvGrouped,
 } from "./charts.js";
 import { renderTable } from "./table.js";
-import { debounce, resolveDepartureMs } from "./utils.js";
+import { debounce, resolveDepartureMs, effectiveTargetSoc } from "./utils.js";
 import { saveConfig } from "./config-store.js";
 import { requestRemoteSolve } from "./api/api.js";
 import { updateEvPanel } from "./ev-tab.js";
@@ -203,7 +203,7 @@ export function createOptimizerController({ els, services = {} }) {
   function getEvSettings() {
     return els.evEnabled?.checked ? {
       departureTime: resolveDepartureMs(els.evDepartureTime?.value, els.evDepartureDay?.value),
-      targetSoc_percent: parseFloat(els.evTargetSoc?.value) || null,
+      targetSoc_percent: effectiveTargetSoc(els.evTargetSocEntityValue?.dataset.haState, els.evTargetSoc?.value),
     } : null;
   }
 

--- a/app/src/state.js
+++ b/app/src/state.js
@@ -150,6 +150,7 @@ export function snapshotUI(els) {
     evTargetSoc_percent: num(els.evTargetSoc?.value),
     evSocSensor: els.evSocSensor?.value ?? '',
     evPlugSensor: els.evPlugSensor?.value ?? '',
+    evTargetSocEntity: els.evTargetSocEntity?.value ?? '',
 
     // EV native-charging feature parity
     evStartTime: els.evStartTime?.value ?? '',
@@ -253,6 +254,7 @@ export function hydrateUI(els, obj = {}) {
   setIfDef(els.evTargetSoc, obj.evTargetSoc_percent);
   setIfDef(els.evSocSensor, obj.evSocSensor);
   setIfDef(els.evPlugSensor, obj.evPlugSensor);
+  setIfDef(els.evTargetSocEntity, obj.evTargetSocEntity);
 
   // EV native-charging feature parity
   setIfDef(els.evStartTime, obj.evStartTime);

--- a/app/src/ui-binding.js
+++ b/app/src/ui-binding.js
@@ -181,8 +181,10 @@ export function getElements() {
     evTargetSocQuickSet: $("#ev-target-soc-quick-set"),
     evSocSensor: $("#ev-soc-sensor"),
     evPlugSensor: $("#ev-plug-sensor"),
+    evTargetSocEntity: $("#ev-target-soc-entity"),
     evSocValue: $("#ev-soc-value"),
     evPlugValue: $("#ev-plug-value"),
+    evTargetSocEntityValue: $("#ev-target-soc-entity-value"),
 
     // EV native-charging feature parity (EV tab)
     evStartTime: $("#ev-start-time"),

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -24,6 +24,18 @@ export function resolveDepartureMs(timeStr, day, now = Date.now()) {
   return Number.isFinite(ms) ? ms : null;
 }
 
+// Effective EV target SoC for display, mirroring the backend resolver
+// (api/services/ev-target-soc.ts): the live `evTargetSocEntity` state wins over
+// the static Target SoC field whenever it is usable, so the chart's target line
+// and the table's departure cell show the number the plan and the charger both
+// actually used. Non-numeric or non-positive states fall back to the setting,
+// exactly like the server does. Both unusable → null (no target drawn).
+export function effectiveTargetSoc(liveState, staticValue) {
+  const live = parseFloat(liveState);
+  if (Number.isFinite(live) && live > 0) return Math.min(100, live);
+  return parseFloat(staticValue) || null;
+}
+
 export function escapeHtml(value) {
   return String(value)
     .replaceAll('&', '&amp;')

--- a/optivolt/config.yaml
+++ b/optivolt/config.yaml
@@ -1,6 +1,6 @@
 name: Optivolt
 slug: optivolt
-version: "0.7.45"
+version: "0.7.46"
 description: Plan and control Victron ESS with forecasts & dynamic tariffs!
 url: https://github.com/vervoto1/optivolt
 image: "ghcr.io/vervoto1/{arch}-addon-optivolt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optivolt",
-  "version": "0.7.45",
+  "version": "0.7.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optivolt",
-      "version": "0.7.45",
+      "version": "0.7.46",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optivolt",
-  "version": "0.7.45",
+  "version": "0.7.46",
   "description": "Optivolt is a linear and mixed-integer optimizer for home energy systems.",
   "homepage": "https://github.com/bmesuere/optivolt#readme",
   "bugs": {

--- a/tests/api/services/config-builder.test.js
+++ b/tests/api/services/config-builder.test.js
@@ -594,12 +594,50 @@ describe('getSolverInputs — EV state fetching from HA', () => {
       return Promise.resolve({ entity_id: entityId, state, attributes: {}, last_changed: '', last_updated: '' });
     });
 
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const { getSolverInputs } = await import('../../../api/services/config-builder.ts');
 
     const { cfg, evState } = await getSolverInputs();
 
     expect(cfg.ev.evTargetSoc_percent).toBe(60);
     expect(evState.targetSoc_percent).toBe(60);
+    // Every failure path is silent by design, so the override has to announce
+    // itself — otherwise a plan built to 60% looks identical in the log to one
+    // built to the 80% the user actually typed.
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('target SoC 60% read from number.tesla_charge_limit'));
+    logSpy.mockRestore();
+  });
+
+  it('stays quiet when the live target agrees with the setting', async () => {
+    loadSettings.mockResolvedValue({
+      ...makeEvSettings(),
+      evMinChargeCurrent_A: 6,
+      evMaxChargeCurrent_A: 16,
+      evBatteryCapacity_kWh: 60,
+      evDepartureTime: '2024-01-01T14:00:00Z',
+      evTargetSoc_percent: 80,
+      evTargetSocEntity: 'number.tesla_charge_limit',
+      evChargeEfficiency_percent: 100,
+    });
+    loadData.mockResolvedValue(makeData());
+    loadCalibration.mockResolvedValue(null);
+
+    fetchHaEntityState.mockImplementation(({ entityId }) => {
+      const state = entityId === 'sensor.ev_soc' ? '75'
+        : entityId === 'number.tesla_charge_limit' ? '80'
+          : 'connected';
+      return Promise.resolve({ entity_id: entityId, state, attributes: {}, last_changed: '', last_updated: '' });
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { getSolverInputs } = await import('../../../api/services/config-builder.ts');
+
+    const { cfg, evState } = await getSolverInputs();
+
+    expect(cfg.ev.evTargetSoc_percent).toBe(80);
+    expect(evState.targetSoc_percent).toBe(80);
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('target SoC'));
+    logSpy.mockRestore();
   });
 
   it('falls back to the static target when the target-SoC entity is unreadable', async () => {

--- a/tests/api/services/config-builder.test.js
+++ b/tests/api/services/config-builder.test.js
@@ -573,6 +573,63 @@ describe('getSolverInputs — EV state fetching from HA', () => {
     expect(cfg.ev.evDepartureSlot).toBe(8);
   });
 
+  it('plans to the live target-SoC entity instead of the static setting', async () => {
+    loadSettings.mockResolvedValue({
+      ...makeEvSettings(),
+      evMinChargeCurrent_A: 6,
+      evMaxChargeCurrent_A: 16,
+      evBatteryCapacity_kWh: 60,
+      evDepartureTime: '2024-01-01T14:00:00Z',
+      evTargetSoc_percent: 80,
+      evTargetSocEntity: 'number.tesla_charge_limit',
+      evChargeEfficiency_percent: 100,
+    });
+    loadData.mockResolvedValue(makeData());
+    loadCalibration.mockResolvedValue(null);
+
+    fetchHaEntityState.mockImplementation(({ entityId }) => {
+      const state = entityId === 'sensor.ev_soc' ? '75'
+        : entityId === 'number.tesla_charge_limit' ? '60'
+          : 'connected';
+      return Promise.resolve({ entity_id: entityId, state, attributes: {}, last_changed: '', last_updated: '' });
+    });
+
+    const { getSolverInputs } = await import('../../../api/services/config-builder.ts');
+
+    const { cfg, evState } = await getSolverInputs();
+
+    expect(cfg.ev.evTargetSoc_percent).toBe(60);
+    expect(evState.targetSoc_percent).toBe(60);
+  });
+
+  it('falls back to the static target when the target-SoC entity is unreadable', async () => {
+    loadSettings.mockResolvedValue({
+      ...makeEvSettings(),
+      evMinChargeCurrent_A: 6,
+      evMaxChargeCurrent_A: 16,
+      evBatteryCapacity_kWh: 60,
+      evDepartureTime: '2024-01-01T14:00:00Z',
+      evTargetSoc_percent: 80,
+      evTargetSocEntity: 'number.tesla_charge_limit',
+      evChargeEfficiency_percent: 100,
+    });
+    loadData.mockResolvedValue(makeData());
+    loadCalibration.mockResolvedValue(null);
+
+    fetchHaEntityState.mockImplementation(({ entityId }) => {
+      if (entityId === 'number.tesla_charge_limit') return Promise.reject(new Error('entity gone'));
+      const state = entityId === 'sensor.ev_soc' ? '75' : 'connected';
+      return Promise.resolve({ entity_id: entityId, state, attributes: {}, last_changed: '', last_updated: '' });
+    });
+
+    const { getSolverInputs } = await import('../../../api/services/config-builder.ts');
+
+    const { cfg, evState } = await getSolverInputs();
+
+    expect(cfg.ev.evTargetSoc_percent).toBe(80);
+    expect(evState.targetSoc_percent).toBeUndefined();
+  });
+
   it('falls back to end-of-horizon (keeps EV planning) when the ready-by deadline has elapsed', async () => {
     loadSettings.mockResolvedValue({
       ...makeEvSettings(),

--- a/tests/api/services/ev-decision-service.test.js
+++ b/tests/api/services/ev-decision-service.test.js
@@ -176,6 +176,48 @@ describe('computeEvDecision — priority + gating', () => {
   });
 });
 
+describe('computeEvDecision — target SoC from an HA entity', () => {
+  beforeEach(() => { vi.clearAllMocks(); delete process.env.SUPERVISOR_TOKEN; });
+
+  function mockHaWithTarget({ soc, plug = 'on', target }) {
+    fetchHaEntityState.mockImplementation(async ({ entityId }) => {
+      if (entityId === 'sensor.soc') return { state: String(soc) };
+      if (entityId === 'sensor.plug') return { state: String(plug) };
+      if (entityId === 'number.charge_limit') {
+        if (target instanceof Error) throw target;
+        return { state: String(target) };
+      }
+      throw new Error(`unknown entity ${entityId}`);
+    });
+  }
+
+  it('stops a planned charge at the live entity target, not the stale setting', async () => {
+    // Car limit lowered to 70% in its own app; the setting still says 80%.
+    mockHaWithTarget({ soc: '75', target: '70' });
+    const settings = makeSettings({ evTargetSocEntity: 'number.charge_limit' });
+    const d = await computeEvDecision(settings, makePlan({ evCharge: 11040 }), NOW);
+    expect(d.targetSoc_percent).toBe(70);
+    expect(d.mode).toBe('idle');
+    expect(d.reason).toMatch(/at\/above target 70%/);
+  });
+
+  it('falls back to the setting when the target entity is unreadable', async () => {
+    mockHaWithTarget({ soc: '75', target: new Error('entity gone') });
+    const settings = makeSettings({ evTargetSocEntity: 'number.charge_limit' });
+    const d = await computeEvDecision(settings, makePlan({ evCharge: 11040 }), NOW);
+    expect(d.targetSoc_percent).toBe(80);
+    expect(d.mode).toBe('planned');
+    expect(d.is_charging).toBe(true);
+  });
+
+  it('keeps the setting when no target entity is configured', async () => {
+    mockHa({ soc: '75', plug: 'on' });
+    const d = await computeEvDecision(makeSettings(), makePlan({ evCharge: 11040 }), NOW);
+    expect(d.targetSoc_percent).toBe(80);
+    expect(d.mode).toBe('planned');
+  });
+});
+
 describe('computeEvDecision — no plan / no row / no departure', () => {
   beforeEach(() => { vi.clearAllMocks(); delete process.env.SUPERVISOR_TOKEN; });
 

--- a/tests/api/services/ev-target-soc.test.js
+++ b/tests/api/services/ev-target-soc.test.js
@@ -28,9 +28,9 @@ describe('parseTargetSocState', () => {
     expect(parseTargetSocState('72.5')).toBe(72.5);
   });
 
-  it('clamps to 0-100', () => {
+  it('clamps above 100', () => {
     expect(parseTargetSocState('130')).toBe(100);
-    expect(parseTargetSocState('-5')).toBe(0);
+    expect(parseTargetSocState('100')).toBe(100);
   });
 
   it('returns null for non-numeric states', () => {
@@ -38,6 +38,16 @@ describe('parseTargetSocState', () => {
     expect(parseTargetSocState('unknown')).toBeNull();
     expect(parseTargetSocState('')).toBeNull();
     expect(parseTargetSocState(undefined)).toBeNull();
+  });
+
+  // A 0% charge limit is nobody's setting — it is an unsynced input_number, a
+  // template sensor evaluating to 0, or the wrong entity id. Taking it literally
+  // would plan no EV charge, clamp evMinSocFloor_percent to 0, and idle every
+  // slot on the liveSoc >= targetSoc cutoff, all without a fallback firing.
+  it('returns null for zero and negative states', () => {
+    expect(parseTargetSocState('0')).toBeNull();
+    expect(parseTargetSocState('0.0')).toBeNull();
+    expect(parseTargetSocState('-5')).toBeNull();
   });
 });
 
@@ -99,5 +109,15 @@ describe('resolveEvTargetSoc', () => {
 
   it('falls back to the setting when no entity is configured', async () => {
     await expect(resolveEvTargetSoc(makeSettings({ evTargetSocEntity: '' }))).resolves.toBe(80);
+  });
+});
+
+describe('fetchEvTargetSoc — unusable entity states fall back', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('returns null when the entity reports 0 (unsynced helper / wrong entity)', async () => {
+    fetchHaEntityState.mockResolvedValue({ state: '0' });
+    await expect(fetchEvTargetSoc(makeSettings())).resolves.toBeNull();
+    await expect(resolveEvTargetSoc(makeSettings())).resolves.toBe(80);
   });
 });

--- a/tests/api/services/ev-target-soc.test.js
+++ b/tests/api/services/ev-target-soc.test.js
@@ -1,0 +1,103 @@
+// @ts-nocheck
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../api/services/ha-client.ts', () => ({
+  fetchHaEntityState: vi.fn(),
+}));
+
+import {
+  parseTargetSocState,
+  fetchEvTargetSoc,
+  resolveEvTargetSoc,
+} from '../../../api/services/ev-target-soc.ts';
+import { fetchHaEntityState } from '../../../api/services/ha-client.ts';
+
+function makeSettings(overrides = {}) {
+  return {
+    evTargetSoc_percent: 80,
+    evTargetSocEntity: 'number.tesla_charge_limit',
+    haUrl: 'ws://ha.local:8123/api/websocket',
+    haToken: 'tok',
+    ...overrides,
+  };
+}
+
+describe('parseTargetSocState', () => {
+  it('parses a numeric state', () => {
+    expect(parseTargetSocState('90')).toBe(90);
+    expect(parseTargetSocState('72.5')).toBe(72.5);
+  });
+
+  it('clamps to 0-100', () => {
+    expect(parseTargetSocState('130')).toBe(100);
+    expect(parseTargetSocState('-5')).toBe(0);
+  });
+
+  it('returns null for non-numeric states', () => {
+    expect(parseTargetSocState('unavailable')).toBeNull();
+    expect(parseTargetSocState('unknown')).toBeNull();
+    expect(parseTargetSocState('')).toBeNull();
+    expect(parseTargetSocState(undefined)).toBeNull();
+  });
+});
+
+describe('fetchEvTargetSoc', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('reads the configured entity', async () => {
+    fetchHaEntityState.mockResolvedValue({ state: '90' });
+    await expect(fetchEvTargetSoc(makeSettings())).resolves.toBe(90);
+    expect(fetchHaEntityState).toHaveBeenCalledWith({
+      haUrl: 'ws://ha.local:8123/api/websocket',
+      haToken: 'tok',
+      entityId: 'number.tesla_charge_limit',
+    });
+  });
+
+  it('returns null (no HA call) when no entity is configured', async () => {
+    await expect(fetchEvTargetSoc(makeSettings({ evTargetSocEntity: '' }))).resolves.toBeNull();
+    await expect(fetchEvTargetSoc(makeSettings({ evTargetSocEntity: '   ' }))).resolves.toBeNull();
+    await expect(fetchEvTargetSoc(makeSettings({ evTargetSocEntity: undefined }))).resolves.toBeNull();
+    expect(fetchHaEntityState).not.toHaveBeenCalled();
+  });
+
+  it('returns null (no HA call) when HA is not configured', async () => {
+    await expect(fetchEvTargetSoc(makeSettings({ haUrl: '' }))).resolves.toBeNull();
+    expect(fetchHaEntityState).not.toHaveBeenCalled();
+  });
+
+  it('reads through the supervisor proxy in add-on mode (no haUrl)', async () => {
+    process.env.SUPERVISOR_TOKEN = 'supervisor-token';
+    fetchHaEntityState.mockResolvedValue({ state: '70' });
+    await expect(fetchEvTargetSoc(makeSettings({ haUrl: '' }))).resolves.toBe(70);
+    expect(fetchHaEntityState).toHaveBeenCalledOnce();
+  });
+
+  it('returns null when HA is unreachable', async () => {
+    fetchHaEntityState.mockRejectedValue(new Error('HA unreachable'));
+    await expect(fetchEvTargetSoc(makeSettings())).resolves.toBeNull();
+  });
+
+  it('returns null when the entity state is not a number', async () => {
+    fetchHaEntityState.mockResolvedValue({ state: 'unavailable' });
+    await expect(fetchEvTargetSoc(makeSettings())).resolves.toBeNull();
+  });
+});
+
+describe('resolveEvTargetSoc', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('prefers the live entity value over the setting', async () => {
+    fetchHaEntityState.mockResolvedValue({ state: '65' });
+    await expect(resolveEvTargetSoc(makeSettings())).resolves.toBe(65);
+  });
+
+  it('falls back to the setting when the entity is unreadable', async () => {
+    fetchHaEntityState.mockRejectedValue(new Error('boom'));
+    await expect(resolveEvTargetSoc(makeSettings())).resolves.toBe(80);
+  });
+
+  it('falls back to the setting when no entity is configured', async () => {
+    await expect(resolveEvTargetSoc(makeSettings({ evTargetSocEntity: '' }))).resolves.toBe(80);
+  });
+});

--- a/tests/api/services/settings-schema.test.js
+++ b/tests/api/services/settings-schema.test.js
@@ -479,6 +479,12 @@ describe('settings-schema', () => {
       expect(s.evFailSafeMode).toBe('hold');
     });
 
+    it('trims the target-SoC entity and defaults it to empty', () => {
+      expect(normalizeSettings(validSettings()).evTargetSocEntity).toBe('');
+      const s = normalizeSettings({ ...validSettings(), evTargetSocEntity: '  number.tesla_charge_limit  ' });
+      expect(s.evTargetSocEntity).toBe('number.tesla_charge_limit');
+    });
+
     it('leaves optional numeric levels undefined when absent, allows negative prices', () => {
       const s = normalizeSettings(validSettings());
       expect(s.evMaxPrice_cents_per_kWh).toBeUndefined();

--- a/tests/app/state.test.js
+++ b/tests/app/state.test.js
@@ -616,6 +616,7 @@ describe('updateSummaryUI', () => {
     els.evTargetSoc = { value: '' };
     els.evSocSensor = { value: '' };
     els.evPlugSensor = { value: '' };
+    els.evTargetSocEntity = { value: '' };
     hydrateUI(els, {
       evEnabled: true,
       evMinChargeCurrent_A: 10,
@@ -627,6 +628,7 @@ describe('updateSummaryUI', () => {
       evTargetSoc_percent: 80,
       evSocSensor: 'sensor.ev_soc',
       evPlugSensor: 'sensor.ev_plug',
+      evTargetSocEntity: 'number.tesla_charge_limit',
     });
     expect(els.evMinChargeCurrent.value).toBe('10');
     expect(els.evMaxChargeCurrent.value).toBe('32');
@@ -637,6 +639,7 @@ describe('updateSummaryUI', () => {
     expect(els.evTargetSoc.value).toBe('80');
     expect(els.evSocSensor.value).toBe('sensor.ev_soc');
     expect(els.evPlugSensor.value).toBe('sensor.ev_plug');
+    expect(els.evTargetSocEntity.value).toBe('number.tesla_charge_limit');
   });
 });
 

--- a/tests/app/utils.test.js
+++ b/tests/app/utils.test.js
@@ -3,6 +3,7 @@ import {
   debounce,
   toDatetimeLocal,
   resolveDepartureMs,
+  effectiveTargetSoc,
   escapeHtml,
 } from '../../app/src/utils.js';
 
@@ -120,5 +121,36 @@ describe('debounce', () => {
     vi.advanceTimersByTime(101);
     expect(fn).not.toHaveBeenCalled();
     vi.useRealTimers();
+  });
+});
+
+// Mirrors api/services/ev-target-soc.ts so the chart's target line and the
+// table's departure cell show the number the plan and the charger actually used,
+// not the static field the entity overrode.
+describe('effectiveTargetSoc', () => {
+  it('prefers a usable live entity state over the static field', () => {
+    expect(effectiveTargetSoc('70', '80')).toBe(70);
+    expect(effectiveTargetSoc('72.5', '80')).toBe(72.5);
+  });
+
+  it('clamps a live state above 100', () => {
+    expect(effectiveTargetSoc('130', '80')).toBe(100);
+  });
+
+  it('falls back to the static field for non-numeric live states', () => {
+    expect(effectiveTargetSoc('unavailable', '80')).toBe(80);
+    expect(effectiveTargetSoc('unknown', '80')).toBe(80);
+    expect(effectiveTargetSoc('', '80')).toBe(80);
+    expect(effectiveTargetSoc(undefined, '80')).toBe(80);
+  });
+
+  it('falls back to the static field for zero/negative live states', () => {
+    expect(effectiveTargetSoc('0', '80')).toBe(80);
+    expect(effectiveTargetSoc('-5', '80')).toBe(80);
+  });
+
+  it('returns null when neither source is usable', () => {
+    expect(effectiveTargetSoc(undefined, '')).toBeNull();
+    expect(effectiveTargetSoc('unavailable', undefined)).toBeNull();
   });
 });


### PR DESCRIPTION
## What

The EV target SoC was OptiVolt-only (`evTargetSoc_percent`), so it drifted from the limit the car actually enforces. Adds an optional `evTargetSocEntity` setting — point it at the car's own charge-limit entity (e.g. `number.tesla_charge_limit`) and that value becomes the target.

## Why

A car limit **below** the OptiVolt target is the expensive case: the car stops at its own limit, while the planner keeps seeing "live SoC below target". It goes on booking cheap slots for a charge that can never happen, holds the charger energized, and keeps battery→grid discharge suppressed for a session that is already finished. (A limit above the target is harmless — charging just stops at the lower OptiVolt target.)

## How

`api/services/ev-target-soc.ts` — `parseTargetSocState` / `fetchEvTargetSoc` / `resolveEvTargetSoc`. `fetchEvTargetSoc` never rejects: it returns `null` when no entity is configured, HA isn't reachable/configured, or the state isn't numeric. Values clamp to 0–100.

While set and readable, the live value replaces the static target everywhere the target is used:

| Consumer | Effect |
| --- | --- |
| `config-builder` LP target | Plan charges to the car's limit |
| min-SoC floor clamp | Floor can't exceed the real target |
| opportunistic band bases | Bands sit above the real target |
| `planner-service` EV preview solve | Preview matches the real plan |
| `ev-decision-service` mid-slot cutoff / keep-on | Charger stops at the limit the car enforces |

The read rides along with the existing SoC/plug fetch in `getSolverInputs` (one `Promise.all`, no extra round trip) and is carried on the new exported `EvLiveState`. `evTargetSoc_percent` stays the setting of record and the fallback on every failure path, so behaviour is unchanged when the field is empty — which is the default.

UI: new "Target SoC entity ID (optional)" input in the EV settings card, with the same live "Current value:" readout as the other entity fields.

## Testing

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run test:run` — 116 files, 2399 tests passed
- `npx vitest run --coverage` — 100% statements/branches/functions/lines maintained

New/extended tests cover the parse clamping, every fallback path (no entity, no HA, unreachable, non-numeric state), the add-on supervisor-proxy path, plan-target override + fallback in `getSolverInputs`, and the decision-layer cutoff at a live target of 70% with the setting still at 80%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
