### PR TITLE
perf(ui): render the dashboard instantly on page load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.7.47 - 2026-08-06
+
+- **The dashboard now renders instantly on page load.** Opening the UI used to keep every card invisible until a full boot sequence finished: four Predictions-tab fetches, a settings write-back, and a complete LP solve — several seconds, and worse when the load raced an auto-calculate tick (solves are serialized server-side). Boot is restructured:
+  - New `GET /calculate/last` endpoint serves the server's cached last plan — the same payload shape as `POST /calculate`, plus `computedAtMs`, without triggering a solve. On load the UI hydrates charts, table, summary, and the EV panel from it immediately; the status line shows the plan's age ("Plan loaded (3 min ago)"). With auto-calculate on, this plan is at most one interval old and is exactly what drives the hardware. A fresh solve still runs when no cached plan exists (fresh server start), and a cached plan older than 15 minutes is refreshed in the background after rendering.
+  - Cards reveal before the first plan arrives instead of after — the charts' designed empty states show while the plan loads, so first paint no longer waits on the network.
+  - The Predictions tab is now lazy like the ESS and Settings tabs: its config/adjustments/data fetches and the forecast run (load prediction + Open-Meteo PV fetch) happen on first tab open instead of on every page load.
+  - Settings persists are skipped when the snapshot is byte-identical to what was last persisted — boot no longer POSTs the settings it just loaded straight back to the server.
+
 ## 0.7.46 - 2026-08-06
 
 - **EV target SoC can now be read from the car instead of retyped in OptiVolt.** New optional `evTargetSocEntity` setting ("Target SoC entity ID" in the EV settings card) points at the car's own charge-limit entity — e.g. `number.tesla_charge_limit`. While it is set and readable, its value replaces the static Target SoC everywhere the target is used: the LP target, the min-SoC floor clamp, the opportunistic band bases, the EV preview solve, and the live mid-slot "target reached, stop charging" cutoff. Changing the limit in the car's app is now enough — no second edit in OptiVolt.

--- a/api/routes/calculate.ts
+++ b/api/routes/calculate.ts
@@ -1,11 +1,41 @@
 /* v8 ignore start — import lines are v8 branch-counting artifacts */
 import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
-import { toHttpError } from '../http-errors.ts';
-import { planAndMaybeWrite, getLastEvPreview } from '../services/planner-service.ts';
+import { HttpError, toHttpError } from '../http-errors.ts';
+import { planAndMaybeWrite, getLastPlan, getLastEvPreview } from '../services/planner-service.ts';
+import type { ComputePlanResult } from '../services/planner-service.ts';
 /* v8 ignore end */
 
 const router = express.Router();
+
+function planResponseBody(plan: ComputePlanResult) {
+  const { cfg, timing, result, rows, summary, rebalanceWindow, rebalanceNudge, computedAtMs } = plan;
+  return {
+    solverStatus: result.Status,
+    objectiveValue: result.ObjectiveValue,
+    rows,
+    initialSoc_percent: cfg.initialSoc_percent,
+    tsStart: new Date(timing.startMs).toISOString(),
+    summary,
+    rebalanceWindow,
+    rebalanceNudge,
+    // Present only when the car is disconnected: the EV schedule as it WOULD
+    // be if plugged in now (display-only; never written to Victron).
+    evPreview: getLastEvPreview(),
+    computedAtMs,
+  };
+}
+
+// GET /calculate/last — the cached last plan (kept fresh by auto-calculate),
+// without triggering a solve. Lets the UI hydrate instantly on page load.
+router.get('/last', (_req: Request, res: Response, next: NextFunction) => {
+  const plan = getLastPlan();
+  if (!plan) {
+    next(new HttpError(404, 'No plan computed yet'));
+    return;
+  }
+  res.json(planResponseBody(plan));
+});
 
 router.post('/', async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -18,26 +48,13 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
       writeToVictron: shouldWriteToVictron,
     });
 
-    const { cfg, timing, result, rows, summary, rebalanceWindow, rebalanceNudge } =
-      await planAndMaybeWrite({
-        updateData: shouldUpdateData,
-        writeToVictron: shouldWriteToVictron,
-        forceWrite: true, // manual trigger always writes
-      });
-
-    res.json({
-      solverStatus: result.Status,
-      objectiveValue: result.ObjectiveValue,
-      rows,
-      initialSoc_percent: cfg.initialSoc_percent,
-      tsStart: new Date(timing.startMs).toISOString(),
-      summary,
-      rebalanceWindow,
-      rebalanceNudge,
-      // Present only when the car is disconnected: the EV schedule as it WOULD
-      // be if plugged in now (display-only; never written to Victron).
-      evPreview: getLastEvPreview(),
+    const plan = await planAndMaybeWrite({
+      updateData: shouldUpdateData,
+      writeToVictron: shouldWriteToVictron,
+      forceWrite: true, // manual trigger always writes
     });
+
+    res.json(planResponseBody(plan));
   } catch (error) {
     logCalculateError(error);
     next(toHttpError(error, 500, 'Failed to calculate plan'));

--- a/app/main.js
+++ b/app/main.js
@@ -35,6 +35,20 @@ const els = getElements();
 const optimizer = createOptimizerController({ els });
 let optimizerQuickSettings = null;
 
+// How stale the server's cached plan may be before boot kicks off a fresh
+// solve in the background (the cached plan still renders immediately).
+const CACHED_PLAN_MAX_AGE_MS = 15 * 60_000;
+
+// Predictions is lazy like ESS/Settings: its API fetches and the forecast run
+// (load prediction + Open-Meteo) happen on first tab open, not on page load.
+// Once-only — initPredictionsTab wires listeners; re-running would double-wire.
+let predictionsTabStarted = false;
+function ensurePredictionsTab() {
+  if (predictionsTabStarted) return;
+  predictionsTabStarted = true;
+  void initPredictionsTab();
+}
+
 // ---------- Boot ----------
 boot();
 
@@ -44,7 +58,8 @@ function setupTabSwitcher() {
 
   const tabs = [
     { tab: document.getElementById('tab-optimizer'),   panel: document.getElementById('panel-optimizer') },
-    { tab: document.getElementById('tab-predictions'), panel: document.getElementById('panel-predictions') },
+    { tab: document.getElementById('tab-predictions'), panel: document.getElementById('panel-predictions'),
+      onActivate: ensurePredictionsTab },
     { tab: document.getElementById('tab-ev'),          panel: document.getElementById('panel-ev'),
       onActivate: () => { void refreshEvOverrideState(els); } },
     // ESS tab is lazy: it does no HA traffic until first activated, and stops
@@ -132,7 +147,6 @@ async function boot() {
 
   setupTabSwitcher();
   setupSettingsSubtabs();
-  await initPredictionsTab();
 
   // Wire inputs with callbacks
   wireGlobalInputs(els, {
@@ -157,6 +171,10 @@ async function boot() {
     debounceRun: optimizer.debounceRun,
   });
 
+  // The inputs now mirror the server's persisted settings; mark that snapshot
+  // as clean so the initial run doesn't POST an identical copy straight back.
+  optimizer.seedPersistedConfig();
+
   if (els.status) {
     els.status.textContent =
       source === "api" ? "Loaded settings from API." : "No settings yet (use the VRM buttons).";
@@ -169,12 +187,21 @@ async function boot() {
   // Wire the manual charging override (Auto/Charge/Stop) and seed its active state.
   wireEvOverrideControls(els);
 
-  // Initial compute
-  await optimizer.onRun();
-
-  // Reveal cards on the initial (optimizer) panel after first compute
+  // Reveal the optimizer panel immediately — the charts have designed empty
+  // states, so first paint no longer waits on a solve round-trip.
   const optimizerPanel = document.getElementById('panel-optimizer');
   if (optimizerPanel) revealCards(optimizerPanel);
+
+  // Hydrate from the server's cached plan when one exists (auto-calculate
+  // keeps it fresh) instead of paying for a boot-time solve. Solve only when
+  // there is no cached plan (fresh server start); refresh a stale one in the
+  // background — the UI is already populated either way.
+  const cached = await optimizer.hydrateFromCachedPlan();
+  if (!cached) {
+    await optimizer.onRun();
+  } else if (cached.ageMs > CACHED_PLAN_MAX_AGE_MS) {
+    void optimizer.onRun();
+  }
 }
 
 // ---------- Actions ----------

--- a/app/src/api/api.js
+++ b/app/src/api/api.js
@@ -20,6 +20,10 @@ export function requestRemoteSolve(body = {}) {
   return postJson("/calculate", body);
 }
 
+// The server's cached last plan (kept fresh by auto-calculate) — no solve is
+// triggered. 404s (throws) when no plan has been computed since server start.
+export const fetchLastPlan = () => getJson("/calculate/last");
+
 // --- Data ---
 export function fetchStoredData() {
   return getJson("/data");

--- a/app/src/optimizer-controller.js
+++ b/app/src/optimizer-controller.js
@@ -7,7 +7,7 @@ import {
 import { renderTable } from "./table.js";
 import { debounce, resolveDepartureMs, effectiveTargetSoc } from "./utils.js";
 import { saveConfig } from "./config-store.js";
-import { requestRemoteSolve } from "./api/api.js";
+import { fetchLastPlan, requestRemoteSolve } from "./api/api.js";
 import { updateEvPanel } from "./ev-tab.js";
 import {
   snapshotUI,
@@ -23,6 +23,7 @@ export function createOptimizerController({ els, services = {} }) {
     drawLoadPvGrouped,
     drawPricesStepLines,
     drawSocChart,
+    fetchLastPlan,
     renderTable,
     requestRemoteSolve,
     saveConfig,
@@ -37,6 +38,7 @@ export function createOptimizerController({ els, services = {} }) {
   let lastTableRows = [];
   let lastTableRebalanceWindow = null;
   let lastFlowsRenderData = null;
+  let lastPersistedConfigJson = null;
 
   const debounceRun = deps.debounce(onRun, 250);
   const persistConfigDebounced = deps.debounce((cfg) => {
@@ -66,37 +68,10 @@ export function createOptimizerController({ els, services = {} }) {
       const writeToVictron = !!els.pushToVictron?.checked;
       const result = await deps.requestRemoteSolve({ updateData, writeToVictron });
 
-      const rows = Array.isArray(result?.rows) ? result.rows : [];
       const solverStatus =
         typeof result?.solverStatus === "string" ? result.solverStatus : "OK";
-
-      deps.updatePlanMeta(els, result.initialSoc_percent, result.tsStart);
-      deps.updateSummaryUI(els, result.summary);
-      deps.updateRebalanceNudgeUI(els, result.rebalanceNudge);
       updateRunStatus(solverStatus, writeToVictron);
-
-      const cfgForViz = getVizConfig();
-      const evSettings = getEvSettings();
-
-      lastTableRows = rows;
-      lastTableRebalanceWindow = result.rebalanceWindow ?? null;
-      renderScheduleTable();
-
-      // When the car is disconnected the real plan has no EV; the backend then
-      // returns evPreview — the schedule as it would be if plugged in now. It is
-      // display-only (never applied to Victron) and is confined to the EV tab. The
-      // optimizer overview reflects only the real plan, so the overview charts are
-      // NOT given the preview: the overview SoC chart shows an EV-SoC line only when
-      // the car is actually in the plan (its EV SoC lives in `rows`).
-      const evPreview = result.evPreview ?? null;
-      renderAllCharts(rows, cfgForViz, result.rebalanceWindow ?? null, evSettings);
-      deps.updateEvPanel(
-        els,
-        evPreview?.rows ?? rows,
-        evPreview?.summary ?? result.summary,
-        cfgForViz.stepSize_m,
-        evPreview,
-      );
+      renderPlanResult(result);
     } catch (err) {
       console.error(err);
       if (els.status) {
@@ -110,6 +85,72 @@ export function createOptimizerController({ els, services = {} }) {
         runBtn.disabled = false;
       }
     }
+  }
+
+  // Render everything a solved (or cached) plan drives: plan meta, summary,
+  // rebalance nudge, schedule table, overview charts, and the EV panel.
+  function renderPlanResult(result) {
+    const rows = Array.isArray(result?.rows) ? result.rows : [];
+
+    deps.updatePlanMeta(els, result.initialSoc_percent, result.tsStart);
+    deps.updateSummaryUI(els, result.summary);
+    deps.updateRebalanceNudgeUI(els, result.rebalanceNudge);
+
+    const cfgForViz = getVizConfig();
+    const evSettings = getEvSettings();
+
+    lastTableRows = rows;
+    lastTableRebalanceWindow = result.rebalanceWindow ?? null;
+    renderScheduleTable();
+
+    // When the car is disconnected the real plan has no EV; the backend then
+    // returns evPreview — the schedule as it would be if plugged in now. It is
+    // display-only (never applied to Victron) and is confined to the EV tab. The
+    // optimizer overview reflects only the real plan, so the overview charts are
+    // NOT given the preview: the overview SoC chart shows an EV-SoC line only when
+    // the car is actually in the plan (its EV SoC lives in `rows`).
+    const evPreview = result.evPreview ?? null;
+    renderAllCharts(rows, cfgForViz, result.rebalanceWindow ?? null, evSettings);
+    deps.updateEvPanel(
+      els,
+      evPreview?.rows ?? rows,
+      evPreview?.summary ?? result.summary,
+      cfgForViz.stepSize_m,
+      evPreview,
+    );
+  }
+
+  // Hydrate the UI from the server's cached plan (kept fresh by auto-calculate)
+  // without triggering a solve. Returns { ageMs } when a plan was rendered, or
+  // null when none is available (fresh server start, or the fetch failed) so
+  // the caller can fall back to a full solve.
+  async function hydrateFromCachedPlan() {
+    let result;
+    try {
+      result = await deps.fetchLastPlan();
+    } catch {
+      return null;
+    }
+    if (!Array.isArray(result?.rows) || result.rows.length === 0) return null;
+
+    renderPlanResult(result);
+
+    const ageMs = Number.isFinite(result.computedAtMs)
+      ? Math.max(0, Date.now() - result.computedAtMs)
+      : Infinity;
+
+    if (els.status) {
+      const solverStatus =
+        typeof result.solverStatus === "string" ? result.solverStatus : "OK";
+      if (solverStatus.toLowerCase() !== "optimal") {
+        els.status.textContent = `Plan status: ${solverStatus}`;
+        els.status.className = "text-sm font-medium text-amber-600 dark:text-amber-400";
+      } else {
+        els.status.textContent = `Plan loaded (${formatPlanAge(ageMs)})`;
+        els.status.className = "text-sm font-medium text-emerald-600 dark:text-emerald-400";
+      }
+    }
+    return { ageMs };
   }
 
   function onTableDisplayChange(event) {
@@ -159,12 +200,24 @@ export function createOptimizerController({ els, services = {} }) {
   }
 
   async function persistConfig(cfg = deps.snapshotUI(els)) {
+    // Skip the POST when nothing changed since the last successful persist —
+    // notably the unconditional persist at the start of the boot-time run.
+    const json = JSON.stringify(cfg);
+    if (json === lastPersistedConfigJson) return;
     try {
       await deps.saveConfig(cfg);
+      lastPersistedConfigJson = json;
     } catch (error) {
       console.error("Failed to persist settings", error);
       if (els.status) els.status.textContent = `Settings error: ${error.message}`;
     }
+  }
+
+  // Record the current UI snapshot as already-persisted. Called after boot
+  // hydrates the inputs from the server, so the settings the server just sent
+  // are not immediately POSTed straight back to it.
+  function seedPersistedConfig() {
+    lastPersistedConfigJson = JSON.stringify(deps.snapshotUI(els));
   }
 
   function queuePersistSnapshot() {
@@ -209,6 +262,7 @@ export function createOptimizerController({ els, services = {} }) {
 
   return {
     debounceRun,
+    hydrateFromCachedPlan,
     onFlowsAggregationChange,
     onRun,
     onTableDisplayChange,
@@ -216,5 +270,14 @@ export function createOptimizerController({ els, services = {} }) {
     persistConfigDebounced,
     queuePersistSnapshot,
     renderScheduleTable,
+    seedPersistedConfig,
   };
+}
+
+function formatPlanAge(ageMs) {
+  /* age is Infinity when the cached plan carries no computedAtMs */
+  if (!Number.isFinite(ageMs)) return "age unknown";
+  const minutes = Math.round(ageMs / 60_000);
+  if (minutes < 1) return "just now";
+  return `${minutes} min ago`;
 }

--- a/optivolt/config.yaml
+++ b/optivolt/config.yaml
@@ -1,6 +1,6 @@
 name: Optivolt
 slug: optivolt
-version: "0.7.46"
+version: "0.7.47"
 description: Plan and control Victron ESS with forecasts & dynamic tariffs!
 url: https://github.com/vervoto1/optivolt
 image: "ghcr.io/vervoto1/{arch}-addon-optivolt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optivolt",
-  "version": "0.7.46",
+  "version": "0.7.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optivolt",
-      "version": "0.7.46",
+      "version": "0.7.47",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optivolt",
-  "version": "0.7.46",
+  "version": "0.7.47",
   "description": "Optivolt is a linear and mixed-integer optimizer for home energy systems.",
   "homepage": "https://github.com/bmesuere/optivolt#readme",
   "bugs": {

--- a/tests/api/api.test.js
+++ b/tests/api/api.test.js
@@ -26,7 +26,7 @@ import { startAutoCalculate, stopAutoCalculate } from '../../api/services/auto-c
 import { startDessPriceRefresh, stopDessPriceRefresh } from '../../api/services/dess-price-refresh.ts';
 import { startPvCurtailment, stopPvCurtailment } from '../../api/services/pv-curtailment.ts';
 import { startShoreOptimizer, stopShoreOptimizer } from '../../api/services/shore-optimizer.ts';
-import { planAndMaybeWrite } from '../../api/services/planner-service.ts';
+import { planAndMaybeWrite, getLastPlan, getLastEvPreview } from '../../api/services/planner-service.ts';
 
 async function importRoutes() {
   vi.resetModules();
@@ -197,6 +197,45 @@ describe('Route contracts', () => {
       forceWrite: true,
     });
     expect(res.body.solverStatus).toBe('Optimal');
+  });
+
+  it('GET /calculate/last serves the cached plan without solving', async () => {
+    getLastPlan.mockReturnValue({
+      cfg: { initialSoc_percent: 20 },
+      timing: { startMs: new Date('2024-01-01T00:00:00.000Z').getTime() },
+      result: { Status: 'Optimal', ObjectiveValue: 1.5 },
+      rows: [1, 2, 3],
+      summary: { netGridCost_cents: 10 },
+      rebalanceWindow: null,
+      rebalanceNudge: { show: false },
+      computedAtMs: 1704067100000,
+    });
+    getLastEvPreview.mockReturnValue(null);
+
+    const res = await get(routes.calculateRouter, '/last');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      solverStatus: 'Optimal',
+      objectiveValue: 1.5,
+      rows: [1, 2, 3],
+      initialSoc_percent: 20,
+      tsStart: '2024-01-01T00:00:00.000Z',
+      summary: { netGridCost_cents: 10 },
+      evPreview: null,
+      computedAtMs: 1704067100000,
+    });
+    expect(planAndMaybeWrite).not.toHaveBeenCalled();
+  });
+
+  it('GET /calculate/last returns 404 when no plan has been computed yet', async () => {
+    getLastPlan.mockReturnValue(undefined);
+
+    const res = await get(routes.calculateRouter, '/last');
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('No plan computed yet');
+    expect(planAndMaybeWrite).not.toHaveBeenCalled();
   });
 
   it('GET /plan-accuracy returns null report when no data exists', async () => {

--- a/tests/app/api/api.test.js
+++ b/tests/app/api/api.test.js
@@ -11,6 +11,7 @@ import {
   fetchStoredSettings,
   saveStoredSettings,
   requestRemoteSolve,
+  fetchLastPlan,
   refreshVrmSettings,
   fetchHaEntityState,
   fetchPredictionConfig,
@@ -80,6 +81,13 @@ describe('api.js wrappers', () => {
     postJson.mockResolvedValue({});
     await requestRemoteSolve();
     expect(postJson).toHaveBeenCalledWith('/calculate', {});
+  });
+
+  it('fetchLastPlan calls getJson /calculate/last', async () => {
+    getJson.mockResolvedValue({ rows: [1] });
+    const out = await fetchLastPlan();
+    expect(getJson).toHaveBeenCalledWith('/calculate/last');
+    expect(out).toEqual({ rows: [1] });
   });
 
   it('refreshVrmSettings calls postJson /vrm/refresh-settings', async () => {

--- a/tests/app/optimizer-controller.test.js
+++ b/tests/app/optimizer-controller.test.js
@@ -51,6 +51,7 @@ function setupController() {
     drawLoadPvGrouped: vi.fn(),
     drawPricesStepLines: vi.fn(),
     drawSocChart: vi.fn(),
+    fetchLastPlan: vi.fn(),
     renderTable: vi.fn(),
     requestRemoteSolve: vi.fn().mockResolvedValue({
       initialSoc_percent: 42,
@@ -381,5 +382,144 @@ describe('optimizer controller', () => {
     expect(services.drawFlowsBarStackSigned).toHaveBeenLastCalledWith(
       els.flows, expect.anything(), 30, expect.anything(), null, 60,
     );
+  });
+
+  // --- cached-plan hydration (GET /calculate/last) ---
+
+  function cachedPlan(overrides = {}) {
+    return {
+      initialSoc_percent: 42,
+      rows: [{ tIdx: 0, timestampMs: 1714586400000, soc_percent: 55 }],
+      solverStatus: 'Optimal',
+      summary: { netGridCost_cents: 12.5 },
+      tsStart: '2026-05-01T12:00:00.000Z',
+      computedAtMs: Date.now() - 5 * 60_000,
+      ...overrides,
+    };
+  }
+
+  it('hydrates the UI from the cached plan without solving or persisting', async () => {
+    const { controller, els, services, summary } = setupController();
+    services.fetchLastPlan.mockResolvedValue(cachedPlan());
+
+    const result = await controller.hydrateFromCachedPlan();
+
+    expect(result.ageMs).toBeGreaterThanOrEqual(5 * 60_000);
+    expect(result.ageMs).toBeLessThan(5 * 60_000 + 5_000);
+    expect(services.requestRemoteSolve).not.toHaveBeenCalled();
+    expect(services.saveConfig).not.toHaveBeenCalled();
+    expect(services.updatePlanMeta).toHaveBeenCalledWith(els, 42, '2026-05-01T12:00:00.000Z');
+    expect(services.updateSummaryUI).toHaveBeenCalledWith(els, summary);
+    expect(services.renderTable).toHaveBeenCalledTimes(1);
+    expect(services.drawSocChart).toHaveBeenCalledTimes(1);
+    expect(services.updateEvPanel).toHaveBeenCalledTimes(1);
+    expect(els.status.textContent).toBe('Plan loaded (5 min ago)');
+    expect(els.status.className).toContain('text-emerald-600');
+  });
+
+  it('labels a cached plan younger than a minute "just now"', async () => {
+    const { controller, els, services } = setupController();
+    services.fetchLastPlan.mockResolvedValue(cachedPlan({ computedAtMs: Date.now() }));
+
+    await controller.hydrateFromCachedPlan();
+
+    expect(els.status.textContent).toBe('Plan loaded (just now)');
+  });
+
+  it('reports Infinity age when the cached plan carries no computedAtMs', async () => {
+    const { controller, els, services } = setupController();
+    services.fetchLastPlan.mockResolvedValue(cachedPlan({ computedAtMs: undefined }));
+
+    const result = await controller.hydrateFromCachedPlan();
+
+    expect(result.ageMs).toBe(Infinity);
+    expect(els.status.textContent).toBe('Plan loaded (age unknown)');
+  });
+
+  it('shows an amber plan-status notice for a non-optimal cached plan', async () => {
+    const { controller, els, services } = setupController();
+    services.fetchLastPlan.mockResolvedValue(cachedPlan({ solverStatus: 'Infeasible' }));
+
+    await controller.hydrateFromCachedPlan();
+
+    expect(els.status.textContent).toBe('Plan status: Infeasible');
+    expect(els.status.className).toContain('text-amber-600');
+  });
+
+  it('coerces a non-string cached solver status to the non-optimal "OK" notice', async () => {
+    const { controller, els, services } = setupController();
+    services.fetchLastPlan.mockResolvedValue(cachedPlan({ solverStatus: undefined }));
+
+    await controller.hydrateFromCachedPlan();
+
+    expect(els.status.textContent).toBe('Plan status: OK');
+    expect(els.status.className).toContain('text-amber-600');
+  });
+
+  it('returns null when the cached-plan fetch fails (404 or network)', async () => {
+    const { controller, services } = setupController();
+    services.fetchLastPlan.mockRejectedValue(new Error('No plan computed yet'));
+
+    expect(await controller.hydrateFromCachedPlan()).toBeNull();
+    expect(services.updatePlanMeta).not.toHaveBeenCalled();
+  });
+
+  it('returns null for a cached plan with no rows', async () => {
+    const { controller, services } = setupController();
+
+    services.fetchLastPlan.mockResolvedValue(null);
+    expect(await controller.hydrateFromCachedPlan()).toBeNull();
+
+    services.fetchLastPlan.mockResolvedValue(cachedPlan({ rows: [] }));
+    expect(await controller.hydrateFromCachedPlan()).toBeNull();
+
+    expect(services.updatePlanMeta).not.toHaveBeenCalled();
+  });
+
+  it('hydrates from the cached plan without a status element', async () => {
+    const { controller, els, services } = setupController();
+    els.status = null;
+    services.fetchLastPlan.mockResolvedValue(cachedPlan());
+
+    const result = await controller.hydrateFromCachedPlan();
+
+    expect(result).not.toBeNull();
+    expect(services.updatePlanMeta).toHaveBeenCalled();
+  });
+
+  // --- settings persist dirty-check ---
+
+  it('skips the boot-time persist when the snapshot matches the seeded config', async () => {
+    const { controller, els, services } = setupController();
+    controller.seedPersistedConfig();
+
+    await controller.onRun();
+    expect(services.saveConfig).not.toHaveBeenCalled();
+
+    // A real change persists again.
+    els.tableKwh.checked = false;
+    await controller.persistConfig();
+    expect(services.saveConfig).toHaveBeenCalledWith({ tableShowKwh: false });
+  });
+
+  it('does not re-persist an identical snapshot twice', async () => {
+    const { controller, services } = setupController();
+
+    await controller.persistConfig();
+    await controller.persistConfig();
+
+    expect(services.saveConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries persisting after a failed save', async () => {
+    const { controller, services } = setupController();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    services.saveConfig.mockRejectedValueOnce(new Error('disk full'));
+
+    await controller.persistConfig();
+    await controller.persistConfig();
+
+    // The failed attempt does not advance the baseline, so the retry still POSTs.
+    expect(services.saveConfig).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/app/predictions.test.js
+++ b/tests/app/predictions.test.js
@@ -883,3 +883,16 @@ describe('predictions.js', () => {
     }
   });
 });
+
+describe('static wiring', () => {
+  it('lazy-inits the Predictions tab via an activation hook, not during boot()', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const main = readFileSync(resolve(process.cwd(), 'app/main.js'), 'utf8');
+    expect(main).toContain('onActivate: ensurePredictionsTab');
+    // boot() must not eagerly init the Predictions tab — its API fetches and
+    // forecast run (load prediction + Open-Meteo) belong on first tab open.
+    const boot = main.slice(main.indexOf('async function boot()'));
+    expect(boot).not.toContain('initPredictionsTab');
+  });
+});


### PR DESCRIPTION
## Problem

Initial page load took several seconds: `boot()` kept every card invisible (`opacity: 0`) until it had serially awaited four Predictions-tab fetches, a settings write-back, and a full LP solve. It got worse when the load raced an auto-calculate tick — plan computation is serialized server-side and `highs.solve()` blocks the event loop, so every request stalls behind an in-flight solve. Meanwhile the server already held a fresh plan in memory (`lastPlan`, recomputed every auto-calculate interval) with no route exposing it.

## Changes

- **`GET /calculate/last`** — serves the cached `lastPlan` (same payload shape as `POST /calculate`, plus `computedAtMs`) without triggering a solve. Boot hydrates charts, table, summary, and the EV panel from it immediately; the status line shows plan age (*"Plan loaded (3 min ago)"*, amber notice for a non-optimal cached solve). Falls back to a fresh solve when no plan exists yet (fresh server start); a cached plan older than 15 min renders immediately and refreshes in the background.
- **Early reveal** — cards reveal before the first plan arrives; the charts' designed empty states show while it loads, so first paint no longer waits on the network.
- **Lazy Predictions tab** — its config/adjustments/data fetches and the forecast run (load prediction + Open-Meteo PV fetch) move from every page load to first tab open, matching the ESS/Settings tab pattern. Solve-time forecast freshness is unaffected — the `updateData` path already runs the predictors.
- **Persist dirty-check** — `persistConfig()` skips the POST when the snapshot is byte-identical to the last successful persist, seeded at boot after `hydrateUI`; boot no longer POSTs the settings it just loaded straight back.

Version bumped to 0.7.47 (package.json, lockfile, `optivolt/config.yaml`) + changelog entry.

## Note

Stacked on #44 (`feat/ev-target-soc-from-ha-entity`) — this branch includes its two commits, among them the review-hardening commit `6960ac8` which is not yet pushed to the #44 branch. After #44 lands, rebase this branch onto main so its diff shrinks to the four perf changes.

## Verification

`npm run typecheck`, `npm run lint`, `npm run test:run` — 2422 passed, coverage 100% (statements/branches/functions/lines). New tests: `GET /calculate/last` (200 + 404), cached-plan hydration paths (status labels, age, non-optimal, fetch failure, empty rows, no status element), persist dirty-check (seed/skip/dedupe/retry-after-failure), client `fetchLastPlan`, and a static-wiring guard that `boot()` never eagerly inits the Predictions tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)