### PR TITLE
docs: document GET /calculate/last and the precompiled Tailwind build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ The system has three layers. Server/core code is TypeScript ESM executed directl
 - The UI calls the Express API on the same origin. Time-series data is display-only (comes from VRM, not editable).
 
 ### Data flow
-Settings, prediction config, and time-series data are server-owned, persisted as JSON under `DATA_DIR`. The client reads/writes settings via `/settings`, prediction config via `/predictions/config`, and triggers computation via `POST /calculate`. The LP is always built server-side from persisted state — the client never sends LP parameters directly. `evLoad` can be sourced from Home Assistant or injected manually via `POST /data`; electricity prices can come from VRM, `POST /data`, or a Home Assistant sensor.
+Settings, prediction config, and time-series data are server-owned, persisted as JSON under `DATA_DIR`. The client reads/writes settings via `/settings`, prediction config via `/predictions/config`, and triggers computation via `POST /calculate`. On page load the client first hydrates from `GET /calculate/last` — the server's cached plan, kept fresh by auto-calculate — and only solves when no cached plan exists or the cached one is older than 15 minutes (then in the background). The LP is always built server-side from persisted state — the client never sends LP parameters directly. `evLoad` can be sourced from Home Assistant or injected manually via `POST /data`; electricity prices can come from VRM, `POST /data`, or a Home Assistant sensor.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ npm run api       # or: npm run dev  (loads .env.local via dotenv-cli + nodemon)
 
 By default the server listens on `http://localhost:3000`.
 
+The web UI ships a precompiled Tailwind stylesheet (`app/vendor/tailwind.css`). If you change Tailwind classes anywhere under `app/`, rebuild it with `npm run build:css` and commit the result — CI fails when it is stale.
+
 **Environment variables:**
 - `HOST` (default `0.0.0.0`), `PORT` (default `3000`)
 - `DATA_DIR` (default `<repo>/data`); stores `settings.json`, `data.json`, and `prediction-config.json`
@@ -274,6 +276,7 @@ The **API** exposes:
   }
   ```
 - `POST /calculate` — Builds and solves the LP with **HiGHS** from persisted settings/data. Optional body flags: `updateData` refreshes VRM series before solving, and `writeToVictron` attempts an MQTT DESS schedule write.
+- `GET /calculate/last` — Returns the cached last plan (same payload shape as `POST /calculate`, plus `computedAtMs`) without triggering a solve; 404 until a first plan has been computed. The web UI hydrates from this on page load so the dashboard renders instantly instead of waiting for a solve.
 - `POST /vrm/refresh-settings` — Fetches latest Dynamic ESS limits/settings from VRM and persists.
 - `GET /predictions/config` — Reads prediction configuration plus `isAddon`.
 - `POST /predictions/config` — Saves prediction configuration. Home Assistant URL/token are intentionally stored in `/settings`, not this file.


### PR DESCRIPTION
Follow-up docs for #45 and #47:

- README HTTP API list: `GET /calculate/last` (cached plan, no solve, 404 until first plan; what the UI hydrates from on load).
- README local development: the `npm run build:css` step for the precompiled Tailwind stylesheet (CI fails when stale).
- CLAUDE.md data flow: the page-load hydration path (cached plan first, solve only when missing or >15 min stale).

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)