### PR TITLE
fix(lp): don't buy back an inherited below-floor SoC deficit at peak price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.7.48 - 2026-08-06
+## 0.7.49 - 2026-08-07
+
+- **A morning SoC below the minSoc floor no longer makes the plan buy the deficit back at peak price** (#49). The minSoc floor was a soft constraint whose shortfall penalty (50 c/kWh) accrued *every slot*, so a battery that drifted 1% under the floor overnight (idle drain after the evening export dump parked it on the floor) made the LP "restore" the floor in the very first slot — at the day's most expensive price — while the Victron reactive layer treats such a delta as maintained (`idle_maintain_targetsoc`) and does nothing. The plan then diverged from reality for hours and showed a confusing peak-price charge that never happened.
+
+  The floor now acts as a discharge floor rather than a charge target when the plan *starts* below it: until the battery first recovers to the floor, the effective floor follows the no-intervention trajectory (initial SoC minus modeled idle drain), so carrying the inherited deficit is free — it gets absorbed by PV surplus or the cheapest charge window the plan uses anyway. Deepening the deficit stays penalized (the remaining reserve cannot be exported through the floor), and a per-slot recovery latch (monotone binary, only emitted when the plan starts below the floor — the LP is unchanged otherwise) restores the full floor permanently after the first recovery, so the allowance can never be reused to drain below minSoc later in the horizon and erode the floor day over day.
+
+- **Fixed a latent infeasibility: discharge-phase thresholds + SoC below the floor.** The discharge-taper big-M was sized as `threshold - minSoc`, assuming SoC never sits below minSoc — but the floor is soft, so it can. With any discharge threshold configured, a below-floor start made the whole LP infeasible (no plan at all). The M is now sized against SoC's true lower bound (0).
 
 - **Replaced the runtime Tailwind compiler with precompiled CSS.** The UI shipped the Tailwind Play CDN build — 407KB of render-blocking JavaScript that recompiled the stylesheet in the browser on every page load by scanning the 128KB document, costing a few hundred milliseconds of main-thread time before first paint (more on tablets/wall panels). The stylesheet is now built once with the Tailwind CLI (same version, 3.4.17) into `app/vendor/tailwind.css` (~25KB) and committed; the inline Play-CDN config moved to `tailwind.config.js`. Class coverage was audited token-by-token against the compiled output — all utilities used in `app/` (including `!`-important, arbitrary values, and slash-opacity variants) are present; app JavaScript stays build-free. `npm run build:css` regenerates the file and CI fails if it is stale.
 

--- a/lib/build-lp.ts
+++ b/lib/build-lp.ts
@@ -171,6 +171,24 @@ export function buildLP({
   const maxSoc_Wh = (maxSoc_percent / 100) * batteryCapacity_Wh;
   const initialSoc_Wh = (initialSoc_percent / 100) * batteryCapacity_Wh;
 
+  // Inherited-deficit floor ratchet. When the initial SoC is already below the
+  // minSoc floor (overnight idle drain past the horizon end, integer SoC
+  // quantization, a raised floor), the per-slot shortfall penalty must not
+  // force an immediate grid buy-back at whatever the current price is — the
+  // Victron reactive layer treats a small deficit as maintained and does
+  // nothing. Until the battery first recovers to the floor, the effective
+  // floor follows the no-intervention trajectory (initialSoc minus cumulative
+  // idle drain): carrying the inherited deficit is free, deepening it is
+  // penalized as usual. Once SoC crosses the floor, floor_recovered_t latches
+  // to 1 (monotone), restoring the full floor for the rest of the horizon so
+  // the allowance can never be reused to drain below minSoc later (which
+  // would erode the floor a little further every day). Known limitation: a
+  // partial recovery that never reaches the floor keeps the full allowance
+  // alive; with realistic charge rates any planned charge window recovers
+  // completely, so this stays theoretical.
+  const initialShortfall_Wh = Math.max(0, minSoc_Wh - initialSoc_Wh);
+  const floorRatchetActive = initialShortfall_Wh > 0;
+
   // Rebalancing MILP: number of slots remaining in the hold window.
   // Truncate to integer to guard against fractional values from future callers.
   // Clamp to [0, T] — D > T is unsatisfiable; D <= 0 means no rebalancing this solve.
@@ -351,6 +369,10 @@ export function buildLP({
   const batteryToGrid = (t: number) => `battery_to_grid_${t}`;
   const soc = (t: number) => `soc_${t}`;
   const socShortfall = (t: number) => `soc_shortfall_${t}`;
+  // Floor-ratchet recovery latch. Deliberately NOT prefixed "soc_": the
+  // solution parser treats every soc_* column except soc_shortfall_* as the
+  // per-slot SoC value.
+  const floorRecovered = (t: number) => `floor_recovered_${t}`;
   const batteryCharging = (t: number) => `battery_charging_${t}`;
   const cvBin = (k: number, t: number) => `cv_${k}_${t}`;
   const dpBin = (k: number, t: number) => `dp_${k}_${t}`;
@@ -525,8 +547,25 @@ export function buildLP({
     lines.push(` c_battery_charge_mode_${t}: ${pvToBattery(t)} + ${toNum(eta_inv)} ${gridToBattery(t)} - ${toNum(maxChargePower_W)} ${batteryCharging(t)} <= 0`);
     lines.push(` c_battery_discharge_mode_${t}: ${batteryToLoad(t)} + ${batteryToGrid(t)}${batEvTerm} + ${toNum(maxDischargePower_W)} ${batteryCharging(t)} <= ${toNum(maxDischargePower_W)}`);
 
-    // Soft min SOC constraint
-    lines.push(` c_min_soc_${t}: ${socShortfall(t)} + ${soc(t)} >= ${minSoc_Wh}`);
+    // Soft min SOC constraint. With an inherited deficit (ratchet active) the
+    // pre-recovery floor is the no-intervention trajectory instead of minSoc:
+    //   floor_recovered = 0:  shortfall + soc >= minSoc - allowance
+    //                         (= initialSoc - idleDrain·(t+1), so sitting idle
+    //                         costs nothing and no phantom trickle-charge is
+    //                         needed to offset modeled idle drain)
+    //   floor_recovered = 1:  shortfall + soc >= minSoc  (full floor)
+    if (floorRatchetActive) {
+      const allowance_Wh = initialShortfall_Wh + idleDrain_Wh * (t + 1);
+      lines.push(` c_min_soc_${t}: ${socShortfall(t)} + ${soc(t)} - ${toNum(allowance_Wh)} ${floorRecovered(t)} >= ${toNum(minSoc_Wh - allowance_Wh)}`);
+      // Latch: SoC above the floor forces floor_recovered = 1 (M spans the
+      // remaining SoC range above the floor); monotonicity keeps it there.
+      lines.push(` c_floor_rec_${t}: ${soc(t)} - ${toNum(maxSoc_Wh - minSoc_Wh)} ${floorRecovered(t)} <= ${toNum(minSoc_Wh)}`);
+      if (t > 0) {
+        lines.push(` c_floor_rec_mono_${t}: ${floorRecovered(t)} - ${floorRecovered(t - 1)} >= 0`);
+      }
+    } else {
+      lines.push(` c_min_soc_${t}: ${socShortfall(t)} + ${soc(t)} >= ${minSoc_Wh}`);
+    }
 
     // CV phase: cv_k_t = 1 if and only if start-of-slot SoC >= threshold.
     // Forward constraint: forces cv=1 when SoC > threshold.
@@ -553,7 +592,11 @@ export function buildLP({
     // Reverse constraint: forces dp=0 when SoC > threshold.
     //   soc - threshold + M * (1 - dp) >= 0  →  rearranged: -M * dp + soc >= threshold - M
     for (let k = 0; k < dpK; k++) {
-      const tightM = dpThresholdWh[k] - minSoc_Wh;
+      // M sized against SoC's true lower bound (0). The minSoc floor is soft,
+      // so SoC can legitimately sit below it (inherited deficit); sizing M as
+      // threshold - minSoc_Wh makes the forward constraint infeasible in
+      // exactly that state.
+      const tightM = dpThresholdWh[k];
       if (t === 0) {
         // Slot 0: start-of-slot SoC is the known initialSoc_Wh constant
         // Forward: initialSoc + M * dp >= threshold  →  M * dp >= threshold - initialSoc
@@ -818,6 +861,12 @@ export function buildLP({
     for (let k = 0; k < dpK; k++) {
       for (let t = 0; t < T; t++) {
         lines.push(` ${dpBin(k, t)}`);
+      }
+    }
+    // Floor-ratchet recovery latches (only when starting below the minSoc floor)
+    if (floorRatchetActive) {
+      for (let t = 0; t < T; t++) {
+        lines.push(` ${floorRecovered(t)}`);
       }
     }
     // EV on/off binaries

--- a/optivolt/config.yaml
+++ b/optivolt/config.yaml
@@ -1,6 +1,6 @@
 name: Optivolt
 slug: optivolt
-version: "0.7.48"
+version: "0.7.49"
 description: Plan and control Victron ESS with forecasts & dynamic tariffs!
 url: https://github.com/vervoto1/optivolt
 image: "ghcr.io/vervoto1/{arch}-addon-optivolt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optivolt",
-  "version": "0.7.48",
+  "version": "0.7.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optivolt",
-      "version": "0.7.48",
+      "version": "0.7.49",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optivolt",
-  "version": "0.7.48",
+  "version": "0.7.49",
   "description": "Optivolt is a linear and mixed-integer optimizer for home energy systems.",
   "homepage": "https://github.com/bmesuere/optivolt#readme",
   "bugs": {

--- a/tests/lib/build-lp.test.js
+++ b/tests/lib/build-lp.test.js
@@ -611,12 +611,13 @@ describe('buildLP — discharge phase', () => {
     // initialSoc_percent = 50, capacity = 10000, so initialSoc_Wh = 5000
     // threshold 0: 30% = 3000 Wh
     // Forward: -tightM * dp <= initialSoc - threshold = 5000 - 3000 = 2000
-    // tightM = threshold - minSoc = 3000 - 1000 = 2000
+    // tightM = threshold - 0 = 3000 (SoC's true lower bound is 0: the minSoc
+    // floor is soft, so SoC can legitimately sit below it)
     const lp = buildLP({ ...mockData, dischargePhaseThresholds: twoThresholds });
     // c_dp_0_0 should NOT contain soc_ variable
     expect(lp).not.toMatch(/c_dp_0_0:.*soc_/);
-    // Forward constraint for slot 0: -2000 dp_0_0 <= 2000
-    expect(lp).toMatch(/c_dp_0_0: -2000 dp_0_0 <= 2000/);
+    // Forward constraint for slot 0: -3000 dp_0_0 <= 2000
+    expect(lp).toMatch(/c_dp_0_0: -3000 dp_0_0 <= 2000/);
   });
 
   it('generates reverse constraints for slot 0 with initialSoc constant', () => {
@@ -629,8 +630,8 @@ describe('buildLP — discharge phase', () => {
   it('generates forward and reverse constraints for slot t>0', () => {
     const lp = buildLP({ ...mockData, dischargePhaseThresholds: twoThresholds });
     // Forward for k=0, t=1: -soc_0 - tightM * dp <= -threshold
-    // tightM = 3000 - 1000 = 2000, threshold = 3000
-    expect(lp).toMatch(/c_dp_0_1: - soc_0 - 2000 dp_0_1 <= -3000/);
+    // tightM = threshold - 0 = 3000
+    expect(lp).toMatch(/c_dp_0_1: - soc_0 - 3000 dp_0_1 <= -3000/);
     // Reverse for k=0, t=1: revM * dp + soc_{t-1} <= maxSoc
     // revM = 10000 - 3000 = 7000
     expect(lp).toMatch(/c_dp_rev_0_1: 7000 dp_0_1 \+ soc_0 <= 10000/);

--- a/tests/lib/soc-floor-ratchet.test.js
+++ b/tests/lib/soc-floor-ratchet.test.js
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { buildLP } from '../../lib/build-lp.ts';
+import { parseSolution } from '../../lib/parse-solution.ts';
+import highsFactory from '../../vendor/highs-build/highs.js';
+
+// Inherited-deficit floor ratchet (issue #49): when the initial SoC starts
+// below the minSoc floor (overnight idle drain, integer SoC quantization, a
+// raised floor), the plan must NOT buy the deficit back immediately at the
+// current price. The deficit rides on the no-intervention trajectory until
+// solar or the cheapest charge window recovers it; after the first recovery
+// the full floor applies again (no reusing the allowance later in the
+// horizon).
+
+describe('buildLP — SoC floor ratchet (structure)', () => {
+  const T = 2;
+  const base = {
+    load_W: Array(T).fill(0),
+    pv_W: Array(T).fill(0),
+    importPrice: Array(T).fill(10),
+    exportPrice: Array(T).fill(5),
+    stepSize_m: 15,
+    batteryCapacity_Wh: 10000,
+    minSoc_percent: 10, // 1000 Wh
+    maxSoc_percent: 100,
+    idleDrain_W: 40, // 10 Wh per 15-min slot
+  };
+
+  it('emits the unchanged plain floor constraint when initial SoC is at/above the floor', () => {
+    const lp = buildLP({ ...base, initialSoc_percent: 10 });
+    expect(lp).not.toContain('floor_recovered');
+    expect(lp).toMatch(/c_min_soc_0: soc_shortfall_0 \+ soc_0 >= 1000/);
+  });
+
+  it('emits ratchet constraints when initial SoC is below the floor', () => {
+    // initial 5% = 500 Wh → inherited shortfall 500 Wh.
+    // allowance_0 = 500 + 10 = 510 (one slot of idle drain), so the
+    // pre-recovery floor is 1000 - 510 = 490 = the no-intervention SoC.
+    const lp = buildLP({ ...base, initialSoc_percent: 5 });
+    expect(lp).toMatch(/c_min_soc_0: soc_shortfall_0 \+ soc_0 - 510 floor_recovered_0 >= 490/);
+    expect(lp).toMatch(/c_min_soc_1: soc_shortfall_1 \+ soc_1 - 520 floor_recovered_1 >= 480/);
+    // Latch: M = maxSoc - minSoc = 9000; SoC above the floor forces the binary.
+    expect(lp).toMatch(/c_floor_rec_0: soc_0 - 9000 floor_recovered_0 <= 1000/);
+    // Monotone: recovery is permanent.
+    expect(lp).toMatch(/c_floor_rec_mono_1: floor_recovered_1 - floor_recovered_0 >= 0/);
+    // Binaries declared.
+    expect(lp).toMatch(/Binaries[\s\S]*floor_recovered_0[\s\S]*floor_recovered_1/);
+  });
+});
+
+describe('buildLP — SoC floor ratchet (solver behavior)', () => {
+  let highs;
+
+  beforeAll(async () => {
+    highs = await highsFactory({});
+  });
+
+  // Aug 7 scenario shape: morning peak, cheap midday window, evening export
+  // peak. Initial 5% sits 500 Wh below the 10% floor.
+  const T = 12;
+  const cfg = {
+    load_W: Array(T).fill(0),
+    pv_W: Array(T).fill(0),
+    //             morning peak      cheap window     evening export peak
+    importPrice: [50, 50, 50, 50, 10, 10, 10, 10, 45, 45, 45, 45],
+    exportPrice: [45, 45, 45, 45, 5, 5, 5, 5, 40, 40, 40, 40],
+    stepSize_m: 15,
+    batteryCapacity_Wh: 10000,
+    minSoc_percent: 10, // 1000 Wh
+    maxSoc_percent: 100,
+    maxChargePower_W: 5000,
+    maxDischargePower_W: 5000,
+    maxGridImport_W: 10000,
+    maxGridExport_W: 10000,
+    chargeEfficiency_percent: 95,
+    dischargeEfficiency_percent: 95,
+    inverterEfficiency_percent: 95,
+    batteryCost_cent_per_kWh: 1,
+    idleDrain_W: 40, // 10 Wh per slot
+    terminalSocValuation: 'zero',
+    initialSoc_percent: 5, // 500 Wh — 500 Wh below the floor
+  };
+
+  it('rides the inherited deficit instead of buying it back at the morning peak', () => {
+    const result = highs.solve(buildLP(cfg), { mip_rel_gap: 0, mip_abs_gap: 0 });
+    expect(result.Status).toBe('Optimal');
+    const rows = parseSolution(result, cfg, { startMs: 0, stepMin: 15 });
+
+    // No grid charging during the expensive morning slots (was ~2 kW in slot 0
+    // before the fix), and no discharging either — the battery just idles.
+    for (let t = 0; t < 4; t++) {
+      expect(rows[t].g2b).toBeLessThan(1);
+      expect(rows[t].b2g + rows[t].b2l).toBeLessThan(1);
+    }
+    // SoC follows the no-intervention trajectory: 500 - 10 Wh idle drain/slot.
+    expect(rows[3].soc).toBeCloseTo(460, 0);
+
+    // Recovery happens in the cheap window (the charge the plan makes for
+    // arbitrage anyway absorbs the deficit).
+    const cheapCharge = rows.slice(4, 8).reduce((s, r) => s + r.g2b, 0);
+    expect(cheapCharge).toBeGreaterThan(100);
+    expect(rows[7].soc).toBeGreaterThan(1000);
+  });
+
+  it('restores the full floor after recovery: the evening dump stops at minSoc, not at the inherited level', () => {
+    const result = highs.solve(buildLP(cfg), { mip_rel_gap: 0, mip_abs_gap: 0 });
+    const rows = parseSolution(result, cfg, { startMs: 0, stepMin: 15 });
+
+    // Evening export drains the battery, but only down to the 1000 Wh floor —
+    // NOT back down to the 500 Wh the morning started at (that would erode the
+    // floor a little further every day).
+    const eveningExport = rows.slice(8).reduce((s, r) => s + r.b2g, 0);
+    expect(eveningExport).toBeGreaterThan(100);
+    expect(rows[T - 1].soc).toBeGreaterThan(950);
+  });
+
+  it('does not deepen the inherited deficit even when an immediate export would be profitable', () => {
+    // Export pays 50 in the morning while the refill window costs 5: without a
+    // pre-recovery floor the solver would dump the remaining 500 Wh reserve
+    // through the floor and re-buy it cheaply later.
+    const cfg2 = {
+      ...cfg,
+      importPrice: [55, 55, 55, 55, 5, 5, 5, 5, 20, 20, 20, 20],
+      exportPrice: [50, 50, 50, 50, 2, 2, 2, 2, 15, 15, 15, 15],
+    };
+    const result = highs.solve(buildLP(cfg2), { mip_rel_gap: 0, mip_abs_gap: 0 });
+    expect(result.Status).toBe('Optimal');
+    const rows = parseSolution(result, cfg2, { startMs: 0, stepMin: 15 });
+    for (let t = 0; t < 4; t++) {
+      expect(rows[t].b2g + rows[t].b2l).toBeLessThan(1);
+    }
+  });
+
+  it('stays feasible with discharge-phase thresholds while below the floor (big-M regression)', () => {
+    // Before the fix the dp big-M was sized as threshold - minSoc, which made
+    // the forward constraint unsatisfiable whenever SoC sat below the floor.
+    const cfg3 = {
+      ...cfg,
+      dischargePhaseThresholds: [{ soc_percent: 30, maxDischargePower_W: 3000 }],
+    };
+    const result = highs.solve(buildLP(cfg3), { mip_rel_gap: 0, mip_abs_gap: 0 });
+    expect(result.Status).toBe('Optimal');
+  });
+});


### PR DESCRIPTION
Fixes #49.

## Problem

The minSoc floor is a soft constraint whose shortfall penalty (50 c/kWh) accrues **per slot**. A battery that drifts 1% under the floor overnight makes the LP restore the floor in the very first slot — at the day's peak price (~12.6c to recover vs ~367c of accrued penalty for waiting until the 13:00 cheap window). The Victron reactive layer treats the delta as maintained (`idle_maintain_targetsoc`) and does nothing, so the plan diverged from actuals for hours every morning the evening dump parked the battery on the floor.

## Fix: floor ratchet (only active when the plan starts below the floor)

The floor becomes a **discharge floor, not a charge target**, for inherited deficits:

- **Pre-recovery**, the effective floor follows the no-intervention trajectory (`initialSoc − idleDrain·t`): carrying the inherited deficit is free — it gets absorbed by PV surplus or the cheapest charge window the plan charges in anyway. Tracking the drain trajectory (rather than a flat `initialSoc` floor) also prevents a phantom ~50 W grid trickle to offset modeled idle drain. Deepening the deficit stays penalized: the remaining reserve cannot be exported through the floor even when the price spread would pay for it.
- **A monotone `floor_recovered_t` binary latches** once SoC first crosses the floor, permanently restoring the full floor. Without the latch, the evening export dump would drain to the *inherited* level instead of minSoc, eroding the floor ~1%/day.
- When `initialSoc >= minSoc` the emitted LP is **byte-for-byte unchanged** — no new binaries, no behavior change on normal days.

Known (theoretical) limitation, documented in code: a partial recovery that never reaches the floor keeps the full allowance alive; with realistic charge rates any planned charge window recovers completely.

## Also: latent discharge-phase infeasibility

The dp big-M was sized `threshold − minSoc`, assuming SoC never sits below the floor — but the floor is soft, so it can (that's this whole issue). With any discharge threshold configured, a below-floor start made the **entire LP infeasible**. M is now sized against SoC's true lower bound (0). Production currently configures no dp thresholds, which is why 2026-08-07 still solved.

## Tests

New `tests/lib/soc-floor-ratchet.test.js` (structure + real HiGHS solves on the issue's price shape): no morning-peak buy-back + SoC rides the drain trajectory; recovery lands in the cheap window; evening dump stops at minSoc (erosion guard); no deepening even when immediately profitable; dp-threshold below-floor feasibility regression. The buy-back, structure, and dp tests fail against the pre-fix builder. Updated the two dp big-M assertions in `build-lp.test.js`.

Full suite: 2428 tests / 117 files pass; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)