### PR TITLE
ESS alarm chip: don't fire on healthy pack states (0 / Normal / No error / Clear)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.51 - 2026-08-13
+
+- **ESS tab: the BMS alarm chip no longer shows a phantom alarm for a healthy pack.** The idle-state check only recognized `OK`/`none`/`off` (plus empty and the `unavailable`/`unknown` dropout states), so a BMS whose "errors" sensor reports a healthy pack as `0` (a numeric fault bitmask), `Normal`, `No error`, or `Clear` showed a permanent red `⚠ 0` / `⚠ Normal` chip that never cleared. The check now also treats those healthy words and a numeric-zero value (`0`, `0.0`) as "no alarm", while any non-zero fault code or unrecognized text still surfaces as an alarm.
+
 ## 0.7.50 - 2026-08-12
 
 - **ESS tab: BMS alarms are now visible — including which alarm.** A battery card can point at the BMS's alarm/errors text sensor (new per-battery `alarmEntity` setting, e.g. the JK BMS "errors" text sensor). While that sensor reports anything other than an idle state (empty, `OK`, `none`, `off`, `unavailable`, `unknown`), the card header shows a red chip with the alarm text (e.g. "⚠ Cell undervoltage"); it clears on the next poll after the BMS drops the alarm.

--- a/app/src/ess-tab.js
+++ b/app/src/ess-tab.js
@@ -69,14 +69,29 @@ function formatBalancing(value) {
   return `<span class="${cls}">${on ? "On" : "Off"}</span>`;
 }
 
-/** Alarm text-sensor states that mean "no active alarm". */
-const ALARM_IDLE_VALUES = new Set(["", "ok", "none", "off", "unavailable", "unknown"]);
+/**
+ * Alarm text-sensor states that mean "no active alarm". Different BMS "errors"
+ * sensors spell a healthy pack differently: the JK BMS errors sensor emits `OK`,
+ * others report `Normal` / `No error(s)` / `Clear` / `None`, and HA reports a
+ * dropped-out sensor as `unavailable` / `unknown`. A numeric bitmask sensor
+ * (`0` = no fault bits) is handled separately below, since it also covers
+ * `0.0` / `00` and any non-zero code stays an alarm.
+ */
+const ALARM_IDLE_VALUES = new Set([
+  "", "ok", "okay", "none", "off", "no error", "no errors", "no fault", "no faults",
+  "normal", "nominal", "clear", "healthy", "idle", "unavailable", "unknown",
+]);
 
 /** The alarm text to display, or null when the sensor reports no active alarm. */
 export function activeAlarmText(alarm) {
   if (!alarm || alarm.value == null) return null;
   const text = String(alarm.value).trim();
-  return ALARM_IDLE_VALUES.has(text.toLowerCase()) ? null : text;
+  if (ALARM_IDLE_VALUES.has(text.toLowerCase())) return null;
+  // Bitmask "errors" sensors report a healthy pack as 0 (some emit 0.0 / 000);
+  // any non-zero code is a real fault and stays visible (e.g. "⚠ 2").
+  const numeric = Number(text);
+  if (Number.isFinite(numeric) && numeric === 0) return null;
+  return text;
 }
 
 function tileHtml(label, valueHtml) {

--- a/optivolt/config.yaml
+++ b/optivolt/config.yaml
@@ -1,6 +1,6 @@
 name: Optivolt
 slug: optivolt
-version: "0.7.50"
+version: "0.7.51"
 description: Plan and control Victron ESS with forecasts & dynamic tariffs!
 url: https://github.com/vervoto1/optivolt
 image: "ghcr.io/vervoto1/{arch}-addon-optivolt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optivolt",
-  "version": "0.7.50",
+  "version": "0.7.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optivolt",
-      "version": "0.7.50",
+      "version": "0.7.51",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optivolt",
-  "version": "0.7.50",
+  "version": "0.7.51",
   "description": "Optivolt is a linear and mixed-integer optimizer for home energy systems.",
   "homepage": "https://github.com/bmesuere/optivolt#readme",
   "bugs": {

--- a/tests/app/ess-tab.test.js
+++ b/tests/app/ess-tab.test.js
@@ -214,13 +214,27 @@ describe('alarm chip', () => {
     expect(chip.title).toBe('Cell undervoltage');
   });
 
-  it.each(['', '  ', 'OK', 'none', 'off', 'unavailable', 'unknown'])(
-    'hides the chip for the idle sensor state %j', async (value) => {
+  it.each([
+    '', '  ', 'OK', 'okay', 'none', 'off', 'unavailable', 'unknown',
+    'Normal', 'nominal', 'Clear', 'Healthy', 'idle', 'No error', 'No errors', 'No fault', 'No faults',
+    '0', '0.0', '00', ' 0 ',
+  ])('hides the chip for the idle sensor state %j', async (value) => {
+    getEssState.mockResolvedValue(stateWith({ entity: 'sensor.bms0_errors', value }));
+    getEssHistory.mockResolvedValue(emptyHistory);
+
+    await initEssTab();
+    expect(document.querySelector('#ess-batteries [data-alarm]').classList.contains('hidden')).toBe(true);
+  });
+
+  it.each(['2', 'Cell undervoltage', 'Wire resistance', '0x2', '1, 4'])(
+    'still shows the chip for the active alarm state %j', async (value) => {
       getEssState.mockResolvedValue(stateWith({ entity: 'sensor.bms0_errors', value }));
       getEssHistory.mockResolvedValue(emptyHistory);
 
       await initEssTab();
-      expect(document.querySelector('#ess-batteries [data-alarm]').classList.contains('hidden')).toBe(true);
+      const chip = document.querySelector('#ess-batteries [data-alarm]');
+      expect(chip.classList.contains('hidden')).toBe(false);
+      expect(chip.textContent).toBe(`⚠ ${value.trim()}`);
     });
 
   it('hides the chip when no alarm entity is configured or its value is null', async () => {
@@ -254,6 +268,15 @@ describe('alarm chip', () => {
   it('activeAlarmText trims surrounding whitespace from the alarm text', () => {
     expect(activeAlarmText({ entity: 'e', value: '  Wire resistance  ' })).toBe('Wire resistance');
     expect(activeAlarmText(undefined)).toBeNull();
+  });
+
+  it('activeAlarmText treats healthy words and a numeric-zero bitmask as no alarm', () => {
+    for (const idle of ['Normal', 'No error', 'Clear', 0, '0', '0.0']) {
+      expect(activeAlarmText({ entity: 'e', value: idle })).toBeNull();
+    }
+    // A non-zero fault code is a real alarm and surfaces verbatim.
+    expect(activeAlarmText({ entity: 'e', value: 2 })).toBe('2');
+    expect(activeAlarmText({ entity: 'e', value: 'Cell overvoltage' })).toBe('Cell overvoltage');
   });
 });
 


### PR DESCRIPTION
Follow-up to #51 (the deferred alarm idle-word heuristic item).

### Problem
The alarm chip's idle-state check (`ALARM_IDLE_VALUES` in `app/src/ess-tab.js`) only recognized `""`, `ok`, `none`, `off`, `unavailable`, `unknown`. Many BMS "errors" sensors spell a healthy pack differently — a numeric `0` bitmask (no fault bits set), `Normal`, `No error(s)`, `Clear` — none of which were in the set. So those batteries showed a permanent red `⚠ 0` / `⚠ Normal` chip that never cleared, which trains you to stop trusting the chip.

### Fix
`activeAlarmText` now also treats the common healthy words (`normal`, `nominal`, `clear`, `healthy`, `idle`, `no error(s)`, `no fault(s)`, `okay`) and a numeric-zero value as "no alarm". Numeric zero is handled separately from the word set so it also covers `0.0` / `00`; any non-zero fault code (`⚠ 2`) or unrecognized text still surfaces verbatim.

### Tests
- Extended the idle-state `it.each` with the new healthy words and numeric-zero forms.
- Added an active-alarm `it.each` asserting non-zero codes and free-form fault text still show.
- Added direct `activeAlarmText` assertions for the healthy-word and numeric-zero paths.

2515 tests pass, typecheck/lint clean, coverage stays at 100%. Version 0.7.50 → 0.7.51.

### Still deferred (not in this PR)
The alarm still **fails open** when the sensor itself drops out: `unavailable`/`unknown` are treated as idle, so a dead alarm channel looks identical to "all clear". Distinguishing "alarm sensor offline" from "no alarm" is a separate UX decision (a distinct neutral chip rather than a red one), left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)