### PR TITLE
ESS dashboard: alarm-offline chip, SoC-write fence, cell-axis headroom, /ess docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.7.52 - 2026-08-13
+
+- **ESS tab: a dropped BMS alarm sensor now shows a distinct "offline" chip instead of reading as all-clear.** When the alarm entity is configured but the sensor is `unavailable`/`unknown` (or missing from the state read), the card shows an amber **⚠ Alarm sensor offline** chip rather than hiding the chip — a dead alarm channel is no longer indistinguishable from a healthy pack. An active fault still shows the red chip; a healthy pack still shows nothing.
+- **SoC calibration writes are fenced against the adaptive-learning SoC samples.** A manual SoC-register write steps the system SoC discontinuously; if that battery is the system SoC source, the step used to poison the efficiency calibrator's actual-vs-predicted ratio for the straddled slot. Each calibration write is now recorded (`data/soc-calibration-events.json`) and the calibrator skips any SoC-sample pair that straddles a calibration event.
+- **ESS cell-voltage trend axis gets symmetric headroom (2.55–3.70 V).** The floor sat exactly on the 2.60 V UV cutoff, so a dip to the cutoff drew on the axis line and anything below clipped; the floor now sits 0.05 V below it, mirroring the headroom above the 3.65 V OVP.
+- **Docs: the `/ess` route group is now documented in the README API reference** (`GET /ess/state`, `GET /ess/history`, `POST /ess/battery/:index/soc-calibration` with its body/response shape and error statuses).
+
 ## 0.7.51 - 2026-08-13
 
 - **ESS tab: the BMS alarm chip no longer shows a phantom alarm for a healthy pack.** The idle-state check only recognized `OK`/`none`/`off` (plus empty and the `unavailable`/`unknown` dropout states), so a BMS whose "errors" sensor reports a healthy pack as `0` (a numeric fault bitmask), `Normal`, `No error`, or `Clear` showed a permanent red `⚠ 0` / `⚠ Normal` chip that never cleared. The check now also treats those healthy words and a numeric-zero value (`0`, `0.0`) as "no alarm", while any non-zero fault code or unrecognized text still surfaces as an alarm.

--- a/README.md
+++ b/README.md
@@ -293,3 +293,6 @@ The **API** exposes:
 - `GET /ev/current` — Current time slot's EV charging decision (`ev_charge_mode`, `ev_charge_A`, source flows, EV SoC).
 - `GET /ev/schedule` — Full per-slot EV charging schedule from the last computed plan.
 - `GET /ha/entity/:entityId` — Fetch live entity state from Home Assistant (used to validate EV sensor configuration).
+- `GET /ess/state` — Live per-battery + system snapshot for the ESS dashboard (cells, temperatures, SoC, balancing, alarms, and SoC-calibration targets), read in one bulk Home Assistant `/api/states` call. Per-entity tolerant: a missing/renamed id yields a `null` value rather than blanking the tab.
+- `GET /ess/history?hours=&period=` — Trend series (cell voltages, temperatures, per-battery SoC) for the dashboard charts. Prefers pre-aggregated statistics and falls back to raw recorder history for entities without statistics.
+- `POST /ess/battery/:index/soc-calibration` — Writes `{ socPercent }` (whole percent, 0–100) to the battery's configured SoC-calibration `number` entity via HA `number.set_value` — the dashboard's one hardware-write path. Errors: `400` (bad index/value), `404` (no such battery), `422` (ESS disabled / HA unconfigured / no calibration entity), `502` (HA write failed).

--- a/api/services/efficiency-calibrator.ts
+++ b/api/services/efficiency-calibrator.ts
@@ -2,7 +2,8 @@ import path from 'node:path';
 import { resolveDataDir, readJson, writeJson } from './json-store.ts';
 import { getRecentSnapshots } from './plan-history-store.ts';
 import { loadSocSamples, findLatestSampleAtOrBefore } from './soc-tracker.ts';
-import type { CalibrationResult, EvCalibrationResult, AccuracyCurve, PlanSnapshot, PlanSnapshotSlot, SocSample } from '../types.ts';
+import { loadSocCalibrationEvents, calibrationEventInRange } from './soc-calibration-events.ts';
+import type { CalibrationResult, EvCalibrationResult, AccuracyCurve, PlanSnapshot, PlanSnapshotSlot, SocSample, SocCalibrationEvent } from '../types.ts';
 
 const DATA_DIR = resolveDataDir();
 const CALIBRATION_PATH = path.join(DATA_DIR, 'calibration.json');
@@ -101,6 +102,7 @@ export async function calibrate(
 ): Promise<CalibrationResult | null> {
   const snapshots = await getRecentSnapshots(Math.max(minDataDays + 1, 7));
   const samples = await loadSocSamples();
+  const calibrationEvents = await loadSocCalibrationEvents();
 
   if (snapshots.length === 0 || samples.length === 0) {
     console.log(`[calibrator] skipped: ${snapshots.length} snapshots, ${samples.length} samples`);
@@ -118,7 +120,7 @@ export async function calibrate(
   // Collect all ratio samples across all snapshots
   const allRatios: RatioSample[] = [];
   for (const snapshot of snapshots) {
-    collectRatios(snapshot, samples, allRatios);
+    collectRatios(snapshot, samples, calibrationEvents, allRatios);
   }
 
   if (allRatios.length === 0) {
@@ -228,6 +230,7 @@ function isCleanSlot(
 function collectRatios(
   snapshot: PlanSnapshot,
   samples: SocSample[],
+  calibrationEvents: SocCalibrationEvent[],
   out: RatioSample[],
 ): void {
   const now = Date.now();
@@ -243,6 +246,10 @@ function collectRatios(
     const prevSample = findLatestSampleAtOrBefore(samples, prevSlot.timestampMs);
     const curSample = findLatestSampleAtOrBefore(samples, slot.timestampMs);
     if (!prevSample || !curSample) continue;
+
+    // Skip a pair straddling a manual SoC recalibration: the step in the SoC
+    // register is not a real charge/discharge, so its ratio is meaningless.
+    if (calibrationEventInRange(calibrationEvents, prevSample.timestampMs, curSample.timestampMs)) continue;
 
     // Skip slots where load or PV deviated from prediction (confound filter)
     if (!isCleanSlot(slot, curSample)) continue;

--- a/api/services/ess-service.ts
+++ b/api/services/ess-service.ts
@@ -34,6 +34,7 @@ import {
   type HaEntityState,
   type HaHistoryEntry,
 } from './ha-client.ts';
+import { recordSocCalibrationEvent } from './soc-calibration-events.ts';
 import type { HaReading } from '../../lib/ha-postprocess.ts';
 
 // ----------------------------- Response shapes ---------------------------
@@ -329,6 +330,16 @@ export async function calibrateBatterySoc(
     });
   } catch (err) {
     throw new HttpError(502, err instanceof Error ? err.message : 'Failed to write the SoC calibration to Home Assistant');
+  }
+
+  // Fence the adaptive-learning SoC samples: a manual recalibration steps the
+  // system SoC, so record the event and let the efficiency calibrator skip any
+  // sample pair that straddles it. Best-effort — the hardware write already
+  // succeeded, so a bookkeeping failure must not turn into a client error.
+  try {
+    await recordSocCalibrationEvent({ timestampMs: Date.now(), batteryIndex, entity: battery.socCalibrationEntity, value });
+  } catch (err) {
+    console.warn('[ess-service] Failed to record SoC calibration event:', (err as Error).message);
   }
 
   return { entity: battery.socCalibrationEntity, value };

--- a/api/services/soc-calibration-events.ts
+++ b/api/services/soc-calibration-events.ts
@@ -1,0 +1,47 @@
+import path from 'node:path';
+import { resolveDataDir, readJson, writeJson } from './json-store.ts';
+import type { SocCalibrationEvent } from '../types.ts';
+
+const EVENTS_PATH = path.join(resolveDataDir(), 'soc-calibration-events.json');
+
+/**
+ * Retain events for the same window the SoC sampler keeps (30 days). An event
+ * older than every live sample can no longer straddle a sample pair, so it is
+ * pruned on the next write.
+ */
+const MAX_AGE_MS = 30 * 24 * 60 * 60_000;
+
+/** Load recorded SoC calibration events (oldest first). */
+export async function loadSocCalibrationEvents(): Promise<SocCalibrationEvent[]> {
+  // v8 ignore next — v8 try/catch brace artifact
+  try {
+    return await readJson<SocCalibrationEvent[]>(EVENTS_PATH);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+}
+
+/**
+ * Record a SoC calibration event, pruning any older than the retention window.
+ */
+export async function recordSocCalibrationEvent(event: SocCalibrationEvent): Promise<void> {
+  const events = await loadSocCalibrationEvents();
+  const cutoffMs = event.timestampMs - MAX_AGE_MS;
+  const kept = events.filter(e => e.timestampMs >= cutoffMs);
+  kept.push(event);
+  await writeJson(EVENTS_PATH, kept);
+}
+
+/**
+ * True if any calibration event happened in `(afterMs, atOrBeforeMs]` — i.e.
+ * strictly after the earlier sample and at or before the later one, so the
+ * later sample reflects the recalibrated value and the earlier one does not.
+ */
+export function calibrationEventInRange(
+  events: SocCalibrationEvent[],
+  afterMs: number,
+  atOrBeforeMs: number,
+): boolean {
+  return events.some(e => e.timestampMs > afterMs && e.timestampMs <= atOrBeforeMs);
+}

--- a/api/types.ts
+++ b/api/types.ts
@@ -432,6 +432,19 @@ export interface SocSample {
   evPluggedIn?: boolean;
 }
 
+/**
+ * A manual SoC-register calibration write. Recorded so the efficiency
+ * calibrator can skip any SoC-sample pair that straddles the event: a manual
+ * recalibration steps the system SoC discontinuously, which would otherwise
+ * poison the actual-vs-predicted ratio for that slot.
+ */
+export interface SocCalibrationEvent {
+  timestampMs: number;
+  batteryIndex: number;
+  entity: string;
+  value: number;
+}
+
 export interface SlotDeviation {
   timestampMs: number;
   predictedSoc_percent: number;

--- a/app/src/ess-tab.js
+++ b/app/src/ess-tab.js
@@ -70,29 +70,46 @@ function formatBalancing(value) {
 }
 
 /**
- * Alarm text-sensor states that mean "no active alarm". Different BMS "errors"
- * sensors spell a healthy pack differently: the JK BMS errors sensor emits `OK`,
- * others report `Normal` / `No error(s)` / `Clear` / `None`, and HA reports a
- * dropped-out sensor as `unavailable` / `unknown`. A numeric bitmask sensor
- * (`0` = no fault bits) is handled separately below, since it also covers
- * `0.0` / `00` and any non-zero code stays an alarm.
+ * Alarm text-sensor states that mean "no active alarm" (a healthy pack).
+ * Different BMS "errors" sensors spell it differently: the JK BMS errors sensor
+ * emits `OK`, others report `Normal` / `No error(s)` / `Clear` / `None`. A
+ * numeric bitmask sensor (`0` = no fault bits) is handled separately below,
+ * since it also covers `0.0` / `00` while any non-zero code stays an alarm.
  */
 const ALARM_IDLE_VALUES = new Set([
   "", "ok", "okay", "none", "off", "no error", "no errors", "no fault", "no faults",
-  "normal", "nominal", "clear", "healthy", "idle", "unavailable", "unknown",
+  "normal", "nominal", "clear", "healthy", "idle",
 ]);
 
-/** The alarm text to display, or null when the sensor reports no active alarm. */
-export function activeAlarmText(alarm) {
-  if (!alarm || alarm.value == null) return null;
+/**
+ * States that mean the alarm sensor itself is not reporting. These are shown as
+ * a distinct "offline" chip rather than hidden: a dropped alarm channel must not
+ * read as "all clear" — that would silently mask a real fault behind a dead sensor.
+ */
+const ALARM_OFFLINE_VALUES = new Set(["unavailable", "unknown"]);
+
+/**
+ * Classify a battery's alarm sensor:
+ *  - `absent`  — no alarm entity configured (render nothing)
+ *  - `offline` — configured but the sensor is missing/unavailable/unknown
+ *  - `clear`   — the sensor reports a healthy state (render nothing)
+ *  - `alarm`   — an active fault; `text` carries the alarm string
+ */
+export function alarmChipState(alarm) {
+  if (!alarm) return { kind: "absent" };
+  if (alarm.value == null) return { kind: "offline" };
   const text = String(alarm.value).trim();
-  if (ALARM_IDLE_VALUES.has(text.toLowerCase())) return null;
-  // Bitmask "errors" sensors report a healthy pack as 0 (some emit 0.0 / 000);
-  // any non-zero code is a real fault and stays visible (e.g. "⚠ 2").
+  const lower = text.toLowerCase();
+  if (ALARM_OFFLINE_VALUES.has(lower)) return { kind: "offline" };
+  if (ALARM_IDLE_VALUES.has(lower)) return { kind: "clear" };
   const numeric = Number(text);
-  if (Number.isFinite(numeric) && numeric === 0) return null;
-  return text;
+  if (Number.isFinite(numeric) && numeric === 0) return { kind: "clear" };
+  return { kind: "alarm", text };
 }
+
+/** Chip colours toggled by the alarm state: red = active fault, amber = sensor offline. */
+const ALARM_ACTIVE_CLASSES = ["bg-red-100", "text-red-700", "dark:bg-red-900/40", "dark:text-red-300"];
+const ALARM_OFFLINE_CLASSES = ["bg-amber-100", "text-amber-700", "dark:bg-amber-900/40", "dark:text-amber-300"];
 
 function tileHtml(label, valueHtml) {
   return `<div><div class="stat-label">${escapeHtml(label)}</div><div class="stat-value">${valueHtml}</div></div>`;
@@ -135,7 +152,7 @@ function buildBatteryCard(name) {
       <div class="flex items-center justify-between mb-3 gap-2">
         <h3 class="sidebar-label">${escapeHtml(name)}</h3>
         <div class="flex items-center gap-2 min-w-0">
-          <span data-alarm class="hidden truncate rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300 px-2.5 py-0.5 text-sm font-semibold"></span>
+          <span data-alarm class="hidden truncate rounded-full px-2.5 py-0.5 text-sm font-semibold"></span>
           <span data-soc class="hidden rounded-full bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300 px-2.5 py-0.5 text-sm font-semibold"></span>
         </div>
       </div>
@@ -259,12 +276,19 @@ function renderBatteryState(battery, view, index) {
     }
   }
 
-  // Alarm chip — visible only while the alarm text sensor reports an active alarm.
-  const alarmText = activeAlarmText(battery.alarm);
-  if (alarmText) {
-    view.alarmChip.textContent = `⚠ ${alarmText}`;
-    view.alarmChip.title = alarmText;
-    view.alarmChip.classList.remove("hidden");
+  // Alarm chip — red for an active fault, amber when the alarm sensor itself is
+  // offline (so a dropped channel is not read as "all clear"), hidden otherwise.
+  const alarm = alarmChipState(battery.alarm);
+  if (alarm.kind === "alarm") {
+    view.alarmChip.textContent = `⚠ ${alarm.text}`;
+    view.alarmChip.title = alarm.text;
+    view.alarmChip.classList.remove("hidden", ...ALARM_OFFLINE_CLASSES);
+    view.alarmChip.classList.add(...ALARM_ACTIVE_CLASSES);
+  } else if (alarm.kind === "offline") {
+    view.alarmChip.textContent = "⚠ Alarm sensor offline";
+    view.alarmChip.title = "The BMS alarm sensor is unavailable — alarm state unknown";
+    view.alarmChip.classList.remove("hidden", ...ALARM_ACTIVE_CLASSES);
+    view.alarmChip.classList.add(...ALARM_OFFLINE_CLASSES);
   } else {
     view.alarmChip.classList.add("hidden");
   }
@@ -341,9 +365,9 @@ function renderHistory(state, history) {
     if (!view) return;
 
     // Cell voltage trends — one thin line per cell, legend hidden. Pin the axis
-    // to the full JK protection window (2.6–3.7 V: UV protection trips at
-    // 2.60 V, OVP at 3.65 V) so bottom-balancing dips and over-voltage
-    // excursions stay on-scale instead of clipping at the chart edge.
+    // around the full JK protection window (UV protection trips at 2.60 V, OVP at
+    // 3.65 V) with ~0.05 V headroom on each side (2.55–3.70 V), so a dip to the
+    // UV cutoff draws just inside the floor instead of clipping on the axis line.
     const cells = battery.cells ?? [];
     const cellEntries = cells.map((cell, idx) => ({
       label: `Cell ${idx + 1}`,
@@ -351,7 +375,7 @@ function renderHistory(state, history) {
       points: pointsFor(history, cell.entity),
     }));
     const cellsDrawn = renderLineChart(view.trendCanvas, cellEntries, {
-      yTitle: "V", yMin: 2.6, yMax: 3.7, showLegend: false, tooltip: { unit: "V", decimals: 3 },
+      yTitle: "V", yMin: 2.55, yMax: 3.7, showLegend: false, tooltip: { unit: "V", decimals: 3 },
     });
     if (!cellsDrawn) setChartMessage(view.trendCanvas, "No trend data");
 

--- a/optivolt/config.yaml
+++ b/optivolt/config.yaml
@@ -1,6 +1,6 @@
 name: Optivolt
 slug: optivolt
-version: "0.7.51"
+version: "0.7.52"
 description: Plan and control Victron ESS with forecasts & dynamic tariffs!
 url: https://github.com/vervoto1/optivolt
 image: "ghcr.io/vervoto1/{arch}-addon-optivolt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optivolt",
-  "version": "0.7.51",
+  "version": "0.7.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optivolt",
-      "version": "0.7.51",
+      "version": "0.7.52",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optivolt",
-  "version": "0.7.51",
+  "version": "0.7.52",
   "description": "Optivolt is a linear and mixed-integer optimizer for home energy systems.",
   "homepage": "https://github.com/bmesuere/optivolt#readme",
   "bugs": {

--- a/tests/api/services/efficiency-calibrator.test.js
+++ b/tests/api/services/efficiency-calibrator.test.js
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock dependencies
 const mockSnapshots = [];
 const mockSamples = [];
+let mockCalibrationEvents = [];
 let mockCalibration = null;
 let savedCalibration = null;
 
@@ -28,6 +29,12 @@ vi.mock('../../../api/services/soc-tracker.ts', () => ({
     }
     return bestPrior ?? bestNearFuture;
   }),
+}));
+
+// Keep the real (pure) calibrationEventInRange; only the loader reads a file.
+vi.mock('../../../api/services/soc-calibration-events.ts', async (importOriginal) => ({
+  ...(await importOriginal()),
+  loadSocCalibrationEvents: vi.fn(async () => mockCalibrationEvents),
 }));
 
 vi.mock('../../../api/services/json-store.ts', () => ({
@@ -535,8 +542,50 @@ describe('efficiency-calibrator — collectRatios branch coverage', () => {
   beforeEach(() => {
     mockSnapshots.length = 0;
     mockSamples.length = 0;
+    mockCalibrationEvents = [];
     mockCalibration = null;
     savedCalibration = null;
+  });
+  afterEach(() => { mockCalibrationEvents = []; });
+
+  it('skips a sample pair straddling a manual SoC calibration event', async () => {
+    const base = Date.now() - 5 * 24 * 60 * 60_000;
+    const step = 15 * 60_000;
+    const slots = [
+      { timestampMs: base, predictedSoc_percent: 50, chargePower_W: 3000, dischargePower_W: 0, predictedLoad_W: 500, predictedPv_W: 0, strategy: 0 },
+      { timestampMs: base + step, predictedSoc_percent: 55, chargePower_W: 3000, dischargePower_W: 0, predictedLoad_W: 500, predictedPv_W: 0, strategy: 0 },
+    ];
+    mockSamples.push(
+      { timestampMs: base, soc_percent: 50, actualLoad_W: 500, actualPv_W: 0 },
+      { timestampMs: base + step, soc_percent: 54, actualLoad_W: 500, actualPv_W: 0 },
+    );
+
+    // Without an event, this clean pair yields one ratio.
+    mockSnapshots.push(makeSnapshot(slots, base));
+    expect((await calibrate(1))?.sampleCount).toBe(1);
+
+    // A calibration event between the two samples poisons the SoC delta, so the
+    // pair must be dropped and no ratios survive.
+    mockCalibration = null;
+    savedCalibration = null;
+    mockCalibrationEvents = [{ timestampMs: base + step / 2, batteryIndex: 0, entity: 'number.bms0_soc_calibration', value: 80 }];
+    expect(await calibrate(1)).toBeNull();
+  });
+
+  it('keeps a pair when the calibration event falls outside the sample window', async () => {
+    const base = Date.now() - 5 * 24 * 60 * 60_000;
+    const step = 15 * 60_000;
+    mockSnapshots.push(makeSnapshot([
+      { timestampMs: base, predictedSoc_percent: 50, chargePower_W: 3000, dischargePower_W: 0, predictedLoad_W: 500, predictedPv_W: 0, strategy: 0 },
+      { timestampMs: base + step, predictedSoc_percent: 55, chargePower_W: 3000, dischargePower_W: 0, predictedLoad_W: 500, predictedPv_W: 0, strategy: 0 },
+    ], base));
+    mockSamples.push(
+      { timestampMs: base, soc_percent: 50, actualLoad_W: 500, actualPv_W: 0 },
+      { timestampMs: base + step, soc_percent: 54, actualLoad_W: 500, actualPv_W: 0 },
+    );
+    // Event before the earlier sample (== boundary, exclusive) does not straddle the pair.
+    mockCalibrationEvents = [{ timestampMs: base, batteryIndex: 0, entity: 'number.bms0_soc_calibration', value: 80 }];
+    expect((await calibrate(1))?.sampleCount).toBe(1);
   });
 
   it('stops processing slots when a future slot is encountered', async () => {

--- a/tests/api/services/ess-service.test.js
+++ b/tests/api/services/ess-service.test.js
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the HA I/O layer; the service + ha-config run for real.
 vi.mock('../../../api/services/ha-client.ts');
+// Mock the SoC-calibration-event store (the write path records into it).
+vi.mock('../../../api/services/soc-calibration-events.ts');
 
 import {
   fetchHaEntityStates,
@@ -9,6 +11,7 @@ import {
   fetchHaHistory,
   callHaService,
 } from '../../../api/services/ha-client.ts';
+import { recordSocCalibrationEvent } from '../../../api/services/soc-calibration-events.ts';
 import {
   getEssState,
   getEssHistory,
@@ -305,6 +308,26 @@ describe('calibrateBatterySoc', () => {
       data: { value: 85 },
     });
     expect(result).toEqual({ entity: 'number.bms0_soc_calibration', value: 85 });
+    // The write is fenced against the adaptive-learning samples via a recorded event.
+    expect(recordSocCalibrationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ batteryIndex: 0, entity: 'number.bms0_soc_calibration', value: 85, timestampMs: expect.any(Number) }),
+    );
+  });
+
+  it('still resolves when recording the calibration event fails (best-effort fence)', async () => {
+    callHaService.mockResolvedValue(undefined);
+    recordSocCalibrationEvent.mockRejectedValue(new Error('disk full'));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(calibrateBatterySoc(calibratableSettings(), 0, 50))
+      .resolves.toEqual({ entity: 'number.bms0_soc_calibration', value: 50 });
+    expect(callHaService).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not record an event when the hardware write fails', async () => {
+    callHaService.mockRejectedValue(new Error('HA down'));
+    await expect(calibrateBatterySoc(calibratableSettings(), 0, 50)).rejects.toMatchObject({ statusCode: 502 });
+    expect(recordSocCalibrationEvent).not.toHaveBeenCalled();
   });
 
   it('accepts the 0 and 100 boundary values', async () => {

--- a/tests/api/services/soc-calibration-events.test.js
+++ b/tests/api/services/soc-calibration-events.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let store = null;
+
+vi.mock('../../../api/services/json-store.ts', () => ({
+  resolveDataDir: () => '/tmp/test-data',
+  readJson: vi.fn(async () => {
+    if (store === null) {
+      const err = new Error('ENOENT');
+      err.code = 'ENOENT';
+      throw err;
+    }
+    return store;
+  }),
+  writeJson: vi.fn(async (_path, data) => { store = data; }),
+}));
+
+import {
+  loadSocCalibrationEvents,
+  recordSocCalibrationEvent,
+  calibrationEventInRange,
+} from '../../../api/services/soc-calibration-events.ts';
+import { readJson } from '../../../api/services/json-store.ts';
+
+const DAY = 24 * 60 * 60_000;
+
+beforeEach(() => {
+  store = null;
+  vi.clearAllMocks();
+});
+
+describe('loadSocCalibrationEvents', () => {
+  it('returns [] when the file does not exist', async () => {
+    await expect(loadSocCalibrationEvents()).resolves.toEqual([]);
+  });
+
+  it('propagates a non-ENOENT read error', async () => {
+    readJson.mockRejectedValueOnce(new Error('EACCES'));
+    await expect(loadSocCalibrationEvents()).rejects.toThrow('EACCES');
+  });
+});
+
+describe('recordSocCalibrationEvent', () => {
+  it('appends an event to the store', async () => {
+    const ev = { timestampMs: 1_000, batteryIndex: 0, entity: 'number.bms0_soc_calibration', value: 80 };
+    await recordSocCalibrationEvent(ev);
+    await expect(loadSocCalibrationEvents()).resolves.toEqual([ev]);
+  });
+
+  it('prunes events older than the 30-day retention window on write', async () => {
+    const now = 100 * DAY;
+    store = [
+      { timestampMs: now - 40 * DAY, batteryIndex: 0, entity: 'e', value: 50 }, // stale → pruned
+      { timestampMs: now - 10 * DAY, batteryIndex: 0, entity: 'e', value: 60 }, // kept
+    ];
+    const fresh = { timestampMs: now, batteryIndex: 1, entity: 'e', value: 70 };
+    await recordSocCalibrationEvent(fresh);
+    const kept = await loadSocCalibrationEvents();
+    expect(kept.map(e => e.value)).toEqual([60, 70]);
+  });
+});
+
+describe('calibrationEventInRange', () => {
+  const events = [{ timestampMs: 500, batteryIndex: 0, entity: 'e', value: 80 }];
+
+  it('is true when an event falls strictly after afterMs and at/before atOrBeforeMs', () => {
+    expect(calibrationEventInRange(events, 400, 600)).toBe(true);
+    expect(calibrationEventInRange(events, 400, 500)).toBe(true); // inclusive upper bound
+  });
+
+  it('is false at the exclusive lower bound and outside the range', () => {
+    expect(calibrationEventInRange(events, 500, 600)).toBe(false); // exclusive lower bound
+    expect(calibrationEventInRange(events, 600, 700)).toBe(false);
+    expect(calibrationEventInRange([], 0, 1_000)).toBe(false);
+  });
+});

--- a/tests/app/ess-tab.test.js
+++ b/tests/app/ess-tab.test.js
@@ -16,7 +16,7 @@ vi.mock('../../app/src/api/api.js', () => ({
   sendEssSocCalibration: vi.fn(),
 }));
 
-import { initEssTab, deactivateEssTab, activeAlarmText } from '../../app/src/ess-tab.js';
+import { initEssTab, deactivateEssTab, alarmChipState } from '../../app/src/ess-tab.js';
 import { getEssState, getEssHistory, sendEssSocCalibration } from '../../app/src/api/api.js';
 import { renderCellSnapshot, renderLineChart } from '../../app/src/ess-charts.js';
 
@@ -78,7 +78,7 @@ describe('initEssTab — rendering', () => {
     expect(document.getElementById('ess-empty').classList.contains('hidden')).toBe(true);
   });
 
-  it('pins the cell-voltage trend axis to the JK protection window (2.6–3.7 V) with an HTML tooltip', async () => {
+  it('pins the cell-voltage trend axis to the JK protection window with headroom (2.55–3.7 V) and an HTML tooltip', async () => {
     getEssState.mockResolvedValue({
       batteries: [battery('B0')],
       system: null,
@@ -92,7 +92,7 @@ describe('initEssTab — rendering', () => {
     const cellTrendCall = renderLineChart.mock.calls.find(([, , opts]) => opts && opts.yTitle === 'V');
     expect(cellTrendCall).toBeDefined();
     expect(cellTrendCall[2]).toMatchObject({
-      yMin: 2.6, yMax: 3.7, showLegend: false, tooltip: { unit: 'V', decimals: 3 },
+      yMin: 2.55, yMax: 3.7, showLegend: false, tooltip: { unit: 'V', decimals: 3 },
     });
   });
 
@@ -214,11 +214,21 @@ describe('alarm chip', () => {
     expect(chip.title).toBe('Cell undervoltage');
   });
 
+  it('shows the alarm chip in red (not amber) for an active fault', async () => {
+    getEssState.mockResolvedValue(stateWith({ entity: 'sensor.bms0_errors', value: 'Cell undervoltage' }));
+    getEssHistory.mockResolvedValue(emptyHistory);
+
+    await initEssTab();
+    const chip = document.querySelector('#ess-batteries [data-alarm]');
+    expect(chip.classList.contains('bg-red-100')).toBe(true);
+    expect(chip.classList.contains('bg-amber-100')).toBe(false);
+  });
+
   it.each([
-    '', '  ', 'OK', 'okay', 'none', 'off', 'unavailable', 'unknown',
+    '', '  ', 'OK', 'okay', 'none', 'off',
     'Normal', 'nominal', 'Clear', 'Healthy', 'idle', 'No error', 'No errors', 'No fault', 'No faults',
     '0', '0.0', '00', ' 0 ',
-  ])('hides the chip for the idle sensor state %j', async (value) => {
+  ])('hides the chip for the healthy sensor state %j', async (value) => {
     getEssState.mockResolvedValue(stateWith({ entity: 'sensor.bms0_errors', value }));
     getEssHistory.mockResolvedValue(emptyHistory);
 
@@ -237,9 +247,22 @@ describe('alarm chip', () => {
       expect(chip.textContent).toBe(`⚠ ${value.trim()}`);
     });
 
-  it('hides the chip when no alarm entity is configured or its value is null', async () => {
+  it.each(['unavailable', 'unknown'])(
+    'shows a distinct amber offline chip when the alarm sensor reports %j', async (value) => {
+      getEssState.mockResolvedValue(stateWith({ entity: 'sensor.bms0_errors', value }));
+      getEssHistory.mockResolvedValue(emptyHistory);
+
+      await initEssTab();
+      const chip = document.querySelector('#ess-batteries [data-alarm]');
+      expect(chip.classList.contains('hidden')).toBe(false);
+      expect(chip.textContent).toBe('⚠ Alarm sensor offline');
+      expect(chip.classList.contains('bg-amber-100')).toBe(true);
+      expect(chip.classList.contains('bg-red-100')).toBe(false);
+    });
+
+  it('shows the offline chip when configured but the sensor is missing (value null), hides it when no entity is configured', async () => {
     getEssState.mockResolvedValue({
-      batteries: [battery('NoAlarm'), battery('NullAlarm', { alarm: { entity: 'sensor.e', value: null } })],
+      batteries: [battery('NoAlarm'), battery('MissingAlarm', { alarm: { entity: 'sensor.e', value: null } })],
       system: null,
       refreshIntervalSeconds: 30,
       fetchedAtMs: 0,
@@ -248,35 +271,34 @@ describe('alarm chip', () => {
 
     await initEssTab();
     const chips = document.querySelectorAll('#ess-batteries [data-alarm]');
-    expect(chips[0].classList.contains('hidden')).toBe(true);
-    expect(chips[1].classList.contains('hidden')).toBe(true);
+    expect(chips[0].classList.contains('hidden')).toBe(true); // absent
+    expect(chips[1].classList.contains('hidden')).toBe(false); // offline
+    expect(chips[1].textContent).toBe('⚠ Alarm sensor offline');
   });
 
-  it('clears the chip when a poll reports the alarm resolved', async () => {
+  it('swaps a stale alarm chip back to hidden when a poll reports the alarm resolved', async () => {
     vi.useFakeTimers();
     getEssState.mockResolvedValueOnce(stateWith({ entity: 'sensor.bms0_errors', value: 'Wire resistance' }));
     getEssHistory.mockResolvedValue(emptyHistory);
     await initEssTab();
     const chip = document.querySelector('#ess-batteries [data-alarm]');
     expect(chip.classList.contains('hidden')).toBe(false);
+    expect(chip.classList.contains('bg-red-100')).toBe(true);
 
     getEssState.mockResolvedValueOnce(stateWith({ entity: 'sensor.bms0_errors', value: '' }));
     await vi.advanceTimersByTimeAsync(30_000);
     expect(chip.classList.contains('hidden')).toBe(true);
   });
 
-  it('activeAlarmText trims surrounding whitespace from the alarm text', () => {
-    expect(activeAlarmText({ entity: 'e', value: '  Wire resistance  ' })).toBe('Wire resistance');
-    expect(activeAlarmText(undefined)).toBeNull();
-  });
-
-  it('activeAlarmText treats healthy words and a numeric-zero bitmask as no alarm', () => {
-    for (const idle of ['Normal', 'No error', 'Clear', 0, '0', '0.0']) {
-      expect(activeAlarmText({ entity: 'e', value: idle })).toBeNull();
+  it('alarmChipState classifies healthy, offline, absent and active states', () => {
+    expect(alarmChipState(null)).toEqual({ kind: 'absent' });
+    expect(alarmChipState({ entity: 'e', value: null })).toEqual({ kind: 'offline' });
+    expect(alarmChipState({ entity: 'e', value: 'unavailable' })).toEqual({ kind: 'offline' });
+    for (const healthy of ['Normal', 'No error', 'Clear', 0, '0', '0.0', '  OK  ']) {
+      expect(alarmChipState({ entity: 'e', value: healthy })).toEqual({ kind: 'clear' });
     }
-    // A non-zero fault code is a real alarm and surfaces verbatim.
-    expect(activeAlarmText({ entity: 'e', value: 2 })).toBe('2');
-    expect(activeAlarmText({ entity: 'e', value: 'Cell overvoltage' })).toBe('Cell overvoltage');
+    expect(alarmChipState({ entity: 'e', value: '  Wire resistance  ' })).toEqual({ kind: 'alarm', text: 'Wire resistance' });
+    expect(alarmChipState({ entity: 'e', value: 2 })).toEqual({ kind: 'alarm', text: '2' });
   });
 });
 


### PR DESCRIPTION
Clears the four deferred follow-ups noted in #51 / #52. All ESS-dashboard robustness, no new features. Version 0.7.51 → 0.7.52.

### 1. Alarm chip: a dropped sensor is no longer read as "all clear"
The alarm chip previously hid itself for `unavailable`/`unknown` (and a missing entity), so a dead alarm channel looked identical to a healthy pack — it could silently mask a real fault. `activeAlarmText` is refactored into a four-state `alarmChipState` (`absent` / `offline` / `clear` / `alarm`): a configured-but-unreporting sensor now shows a distinct amber **⚠ Alarm sensor offline** chip, an active fault still shows the red chip, and a healthy pack still shows nothing.

### 2. SoC-write fence against the adaptive-learning samples
`POST /ess/battery/:index/soc-calibration` writes the BMS SoC register. If that battery is the system SoC source, the write steps the sampled system SoC discontinuously, and `efficiency-calibrator` computed `actualChange = curSample.soc - prevSample.soc` across that step — poisoning the actual-vs-predicted ratio for the straddled slot (the outlier filter only partly guards). Now each write records a calibration event (`data/soc-calibration-events.json`, new `api/services/soc-calibration-events.ts`), and `collectRatios` skips any sample pair that straddles an event. Recording is best-effort — the hardware write already succeeded, so a bookkeeping failure can't turn into a client error, and a failed write records nothing.

### 3. Cell-voltage trend axis headroom (2.55–3.70 V)
The floor sat exactly on the 2.60 V UV cutoff, so a dip to the cutoff drew on the axis line and anything below clipped — the very excursion the window is meant to show. The floor now sits 0.05 V below it, mirroring the headroom above the 3.65 V OVP at the top.

### 4. Docs
The `/ess` route group is now in the README API reference: `GET /ess/state`, `GET /ess/history`, and `POST /ess/battery/:index/soc-calibration` with its body/response shape and error statuses.

### Verification
2525 tests pass (added: alarm offline-chip + `alarmChipState` classifier, the calibration-event store, the straddle-skip in the calibrator, the ess-service records-event/best-effort paths, axis value). typecheck + lint clean, coverage stays at 100%. No new Tailwind classes needed (amber was already compiled), so `app/vendor/tailwind.css` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)