### PR TITLE
ESS: seed alarm + SoC-calibration entities so the widgets actually turn on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.53 - 2026-08-13
+
+- **ESS tab: the BMS alarm chip and per-battery SoC-calibration widget are now actually enabled.** They shipped in 0.7.50 gated on per-battery `alarmEntity` / `socCalibrationEntity` settings, but ESS config is loaded exclusively from the seeded defaults (persisted/POSTed `essConfig` is intentionally ignored, and there is no settings UI for it yet), and those two keys were never added to the defaults — so the widgets stayed dark on every install. Both entities are now seeded for the JK BMS batteries (`bms0`/`bms1`): the SoC-calibration widget appears immediately, and the alarm chip appears the next time a BMS raises an alarm (it stays hidden for a healthy pack by design).
+
 ## 0.7.52 - 2026-08-13
 
 - **ESS tab: a dropped BMS alarm sensor now shows a distinct "offline" chip instead of reading as all-clear.** When the alarm entity is configured but the sensor is `unavailable`/`unknown` (or missing from the state read), the card shows an amber **⚠ Alarm sensor offline** chip rather than hiding the chip — a dead alarm channel is no longer indistinguishable from a healthy pack. An active fault still shows the red chip; a healthy pack still shows nothing.

--- a/api/defaults/default-settings.json
+++ b/api/defaults/default-settings.json
@@ -140,7 +140,9 @@
         "balancingBinaryEntity": "binary_sensor.jk_bms_jk_bms_bms0_balancing",
         "balancingCurrentEntity": "sensor.jk_bms_jk_bms_bms0_balancing_current",
         "balanceStartVoltageEntity": "number.jk_bms_jk_bms_bms0_balance_starting_voltage",
-        "balanceTriggerVoltageEntity": "number.jk_bms_jk_bms_bms0_balance_trigger_voltage"
+        "balanceTriggerVoltageEntity": "number.jk_bms_jk_bms_bms0_balance_trigger_voltage",
+        "alarmEntity": "sensor.jk_bms_jk_bms_bms0_errors",
+        "socCalibrationEntity": "number.equipment_room_jk_bms_jk_bms_bms0_soc_calibration"
       },
       {
         "name": "Gobel Power",
@@ -165,7 +167,9 @@
         "balancingBinaryEntity": "binary_sensor.jk_bms_jk_bms_bms1_balancing",
         "balancingCurrentEntity": "sensor.jk_bms_jk_bms_bms1_balancing_current",
         "balanceStartVoltageEntity": "number.jk_bms_jk_bms_bms1_balance_starting_voltage",
-        "balanceTriggerVoltageEntity": "number.jk_bms_jk_bms_bms1_balance_trigger_voltage"
+        "balanceTriggerVoltageEntity": "number.jk_bms_jk_bms_bms1_balance_trigger_voltage",
+        "alarmEntity": "sensor.jk_bms_jk_bms_bms1_errors",
+        "socCalibrationEntity": "number.equipment_room_jk_bms_jk_bms_bms1_soc_calibration"
       }
     ],
     "system": {

--- a/optivolt/config.yaml
+++ b/optivolt/config.yaml
@@ -1,6 +1,6 @@
 name: Optivolt
 slug: optivolt
-version: "0.7.52"
+version: "0.7.53"
 description: Plan and control Victron ESS with forecasts & dynamic tariffs!
 url: https://github.com/vervoto1/optivolt
 image: "ghcr.io/vervoto1/{arch}-addon-optivolt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optivolt",
-  "version": "0.7.52",
+  "version": "0.7.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optivolt",
-      "version": "0.7.52",
+      "version": "0.7.53",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optivolt",
-  "version": "0.7.52",
+  "version": "0.7.53",
   "description": "Optivolt is a linear and mixed-integer optimizer for home energy systems.",
   "homepage": "https://github.com/bmesuere/optivolt#readme",
   "bugs": {


### PR DESCRIPTION
Fixes the reason the BMS alarm chip and per-battery SoC-calibration widget never appeared, despite shipping in 0.7.50 (#51).

### Root cause
Both widgets are gated on per-battery `alarmEntity` / `socCalibrationEntity`. But `essConfig` is loaded **exclusively** from `api/defaults/default-settings.json` — `loadSettings` (settings-store.ts:46) sets `mergedEssConfig = defaults.essConfig` and deliberately ignores any persisted or POSTed `essConfig` ("server-owned, no settings UI yet"). The two keys were never added to the seeded defaults, and there is no UI to set them, so the features stayed dark on every install. The "add this on the live system" snippet in the #51 PR description was never reachable through the settings flow.

### Fix
Seed `alarmEntity` and `socCalibrationEntity` for both JK BMS batteries (`bms0` Basen Green / `bms1` Gobel Power), mirroring the confirmed `bms0` IDs onto `bms1`:

| Battery | alarmEntity | socCalibrationEntity |
|---|---|---|
| bms0 | `sensor.jk_bms_jk_bms_bms0_errors` | `number.equipment_room_jk_bms_jk_bms_bms0_soc_calibration` |
| bms1 | `sensor.jk_bms_jk_bms_bms1_errors` | `number.equipment_room_jk_bms_jk_bms_bms1_soc_calibration` |

After the add-on updates: the **SoC-calibration widget appears immediately** on each battery card; the **alarm chip appears the next time a BMS raises an alarm** (it stays hidden for a healthy pack by design — that's the 0.7.51/0.7.53 behavior).

If a `Send` on the SoC widget returns a 502, the `socCalibrationEntity` id is wrong for that battery — correct it here in the defaults.

### Verification
2525 tests pass, typecheck + lint clean. Data-only change (`api/defaults/**` is coverage-excluded). Version 0.7.52 → 0.7.53.

### Follow-up (not in this PR)
The deeper gap: `essConfig` has no settings editor, so every entity change requires editing the baked-in defaults and shipping. The "Phase 7 essConfig editor" that settings-store.ts:45 is waiting for would make these user-configurable at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)